### PR TITLE
Add support for `remaining_bytes` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ see the [spec helper](https://github.com/spider-gazelle/bindata/blob/master/spec
       # Supports custom objects as long as they implement `from_io`
       custom header : ExtHeader = ExtHeader.new
     end
+
+    # optionally read the remaining bytes out of io
+    remaining_bytes :rest
   end
 ```
 

--- a/spec/bindata_remaining_bytes_spec.cr
+++ b/spec/bindata_remaining_bytes_spec.cr
@@ -49,6 +49,17 @@ describe BinData do
     end
   end
 
+  it "runs verification as expected while writing" do
+    r = RemainingBytesData.new
+    r.first = 0x02
+    r.rest = Bytes.new 15
+    io2 = IO::Memory.new
+
+    expect_raises BinData::VerificationException, "Failed to verify writing bytes at RemainingBytesData.rest" do
+      r.write io2
+    end
+  end
+
   it "abides by onlyif as expected" do
     io = IO::Memory.new
     io.write_byte 0x01
@@ -59,5 +70,34 @@ describe BinData do
     r.first.should eq 0x01
     r.rest.size.should eq 0
     io.pos.should eq 1
+  end
+
+  it "abides by onlyif as expected while writing" do
+    r = RemainingBytesData.new
+    r.first = 0x01
+    r.rest = Bytes.new 4
+    io2 = IO::Memory.new
+    r.write io2
+    io2.rewind
+
+    io2.size.should eq 1
+  end
+
+  it "writes remaining bytes" do
+    io = IO::Memory.new
+    io.write_byte 0x02
+    rest = Bytes.new 4, &.to_u8
+    io.write rest
+    io.rewind
+
+    r = RemainingBytesData.new
+    r.first = 0x02
+    r.rest = rest
+
+    io2 = IO::Memory.new
+    r.write io2
+    io2.rewind
+
+    io2.to_slice.should eq(io.to_slice)
   end
 end

--- a/spec/bindata_remaining_bytes_spec.cr
+++ b/spec/bindata_remaining_bytes_spec.cr
@@ -1,0 +1,63 @@
+require "./helper"
+
+describe BinData do
+  it "reads the remaining bytes into Bytes" do
+    io = IO::Memory.new
+    io.write_byte 0x02
+    rest = Bytes.new 4, &.to_u8
+    io.write rest
+    io.rewind
+
+    r = io.read_bytes RemainingBytesData
+    r.first.should eq 0x02
+    r.rest.should eq rest
+  end
+
+  it "reads the remaining bytes into empty Bytes if none remain" do
+    io = IO::Memory.new
+    io.write_byte 0x02
+    io.write Bytes.new 0
+    io.rewind
+
+    r = io.read_bytes RemainingBytesData
+    r.first.should eq 0x02
+    r.rest.size.should eq 0
+  end
+
+  it "reads the rest even if io has already been partially read" do
+    io = IO::Memory.new
+    io.write Bytes.new 10
+    io.write_byte 0x02
+    rest = Bytes.new 4, &.to_u8
+    io.write rest
+    io.rewind
+
+    io.read Bytes.new 10
+    r = io.read_bytes RemainingBytesData
+    r.first.should eq 0x02
+    r.rest.should eq rest
+  end
+
+  it "runs verification as expected" do
+    io = IO::Memory.new
+    io.write_byte 0x02
+    io.write Bytes.new 15
+    io.rewind
+
+    expect_raises BinData::VerificationException, "Failed to verify reading bytes at RemainingBytesData.rest" do
+      io.read_bytes RemainingBytesData
+    end
+  end
+
+  it "abides by onlyif as expected" do
+    io = IO::Memory.new
+    io.write_byte 0x01
+    io.write Bytes.new 4
+    io.rewind
+
+    r = io.read_bytes RemainingBytesData
+    r.first.should eq 0x01
+    r.rest.size.should eq 0
+    io.pos.should eq 1
+  end
+end

--- a/spec/bindata_verify_spec.cr
+++ b/spec/bindata_verify_spec.cr
@@ -34,7 +34,7 @@ describe BinData do
     io2.to_slice.should eq io.to_slice
   end
 
-  it "raised an exception when it fails to verify on read" do
+  it "raises an exception when it fails to verify on read" do
     io = IO::Memory.new
     io.write_byte 0x02
     io.write_byte 0x05
@@ -43,11 +43,11 @@ describe BinData do
     io.rewind
 
     expect_raises BinData::VerificationException, "Failed to verify reading basic at VerifyData.checksum" do
-      r = io.read_bytes VerifyData
+      io.read_bytes VerifyData
     end
   end
 
-  it "raised an exception when it fails to verify on write" do
+  it "raises an exception when it fails to verify on write" do
     io = IO::Memory.new
     io.write_byte 0x02
     io.write_byte 0x05

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -119,3 +119,10 @@ class VerifyData < BinData
   bytes :bytes, length: ->{ size }
   uint8 :checksum, verify: ->{ checksum == bytes.reduce(0) { |acc, i| acc + i } }
 end
+
+class RemainingBytesData < BinData
+  endian big
+
+  uint8 :first
+  remaining_bytes :rest, onlyif: ->{ first == 0x02 }, verify: ->{ rest.size % 2 == 0 }
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -266,6 +266,22 @@ abstract class BinData
         {% end %}
       {% end %}
 
+      {% if REMAINING.size > 0 %}
+        {% if REMAINING[0][:onlyif] %}
+          %onlyif = ({{REMAINING[0][:onlyif]}}).call
+          if %onlyif
+        {% end %}
+        io.write(@{{REMAINING[0][:name]}})
+        {% if REMAINING[0][:onlyif] %}
+          end
+        {% end %}
+        {% if REMAINING[0][:verify] %}
+          if !({{REMAINING[0][:verify]}}).call
+            raise VerificationException.new "Failed to verify writing #{{{REMAINING[0][:type]}}} at {{@type}}.{{REMAINING[0][:name]}}"
+          end
+        {% end %}
+      {% end %}
+
       io
     end
   end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -165,19 +165,19 @@ abstract class BinData
       {% end %}
 
       {% if REMAINING.size > 0 %}
-        {% if REMAINING[0][2] %}
-          %onlyif = ({{REMAINING[0][2]}}).call
+        {% if REMAINING[0][:onlyif] %}
+          %onlyif = ({{REMAINING[0][:onlyif]}}).call
           if %onlyif
         {% end %}
         %buf = Bytes.new io.size - io.pos
         io.read_fully %buf
-        @{{REMAINING[0][1]}} = %buf
-        {% if REMAINING[0][2] %}
+        @{{REMAINING[0][:name]}} = %buf
+        {% if REMAINING[0][:onlyif] %}
           end
         {% end %}
-        {% if REMAINING[0][3] %}
-          if !({{REMAINING[0][3]}}).call
-            raise VerificationException.new "Failed to verify reading #{{{REMAINING[0][0]}}} at {{@type}}.{{REMAINING[0][1]}}"
+        {% if REMAINING[0][:verify] %}
+          if !({{REMAINING[0][:verify]}}).call
+            raise VerificationException.new "Failed to verify reading #{{{REMAINING[0][:type]}}} at {{@type}}.{{REMAINING[0][:name]}}"
           end
         {% end %}
       {% end %}
@@ -402,8 +402,8 @@ abstract class BinData
     {% PARTS << {"group", name.id, name.id.stringify.camelcase.id, onlyif, verify, nil, value, nil} %}
   end
 
-  macro remaining_bytes(name, onlyif = nil, verify = nil, value = nil, default = nil)
-    {% REMAINING << {"bytes", name.id, onlyif, verify} %}
+  macro remaining_bytes(name, onlyif = nil, verify = nil, default = nil)
+    {% REMAINING << {type: "bytes", name: name.id, onlyif: onlyif, verify: verify} %}
     property {{name.id}} : Bytes = {% if default %} {{default}}.to_slice {% else %} Bytes.new(0) {% end %}
   end
 end


### PR DESCRIPTION
Adds the ability to optionally read the remaining bytes out of io. If `remaining_bytes` is specified, it the rest of the io will be read into a Bytes array at the given name.

```crystal
class Demo < BinData
  endian big

  uint8 :first
  remaining_bytes :rest
end
```

