### PR TITLE
Update Object#to_io return type

### DIFF
--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -68,8 +68,9 @@ abstract class BinData
     io
   end
 
-  def to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
+  def to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian) : Int64
     write(io)
+    0i64 # TODO
   end
 
   def self.from_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)


### PR DESCRIPTION
In Crystal 0.35 `IO#write` is supposed to return the written bytes. This propagates down to  `Object#to_io`.

I didn't track how to get the information in bindata implementation. Since this is new feature no other shard is using it right now. I needed this patch to have a working version of https://github.com/crystal-community/jwt

Related to changes in shards 0.11 I recommend adding a crystal property in the shard.yml to state which crystal version are expected to be used with this shard.

If compatibility with older versions is wanted {% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %} can be used.

Feel free to close the PR and use it as input for an actual 🙈  migration.