### PR TITLE
Automatically define helper methods for custom BinData types

### DIFF
--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -35,7 +35,7 @@ class Wow < BinData
   endian big
 
   uint8 :start, value: ->{ 0_u8 }
-  custom header : Header = Header.new
+  header :header
 
   group :body, onlyif: ->{ header.size > 0 } do
     uint8 :start, value: ->{ 1_u8 }, onlyif: ->{ parent.start == 0 }


### PR DESCRIPTION
Thanks for this awesome library! 

This pull request automatically defines DSL methods for previously defined custom types. This match BinData gem behavior and makes it easier to read binary definitions

Example: 

```crystal
class MacAddress < BinData 
  array octets : UInt8,  length: ->{ 6 }
end 

class DummyPacket < BinData
  mac_address :from
  mac_address :to

  string :text, length: 20
end
```