### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: shards install --ignore-crystal-version
+    - name: Lint
+      run: ./bin/ameba
+    - name: Format
+      run: crystal tool format --check
+    - name: Run tests
+      run: crystal spec --error-trace

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BinData provides a declarative way to read and write structured binary data.
 
 This means the programmer specifies what the format of the binary data is, and BinData works out how to read and write data in this format. It is an easier (and more readable) alternative.
 
-[![Build Status](https://travis-ci.org/spider-gazelle/bindata.svg?branch=master)](https://travis-ci.org/spider-gazelle/bindata)
+[![Build Status](https://github.com/spider-gazelle/bindata/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/spider-gazelle/bindata/actions/workflows/CI.yml)
 
 
 ## Usage


### PR DESCRIPTION
Travis builds are failing because crystal environment is quite broken. Since Travis is being phased out this PR replaces it with Github Action