### PR TITLE
Add support of mixed endians

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Then you can specify the structures fields. There are a few different field type
 
 1. Core types
    * `uint8`, `int128` which would accept `UInt8` and `Int128` values respectively
+   * You can use endian-aware types to mix endianess: ex `uint32le` will read `UInt32` regardless of `endian` set in class
 2. Custom types
    * anything that is [io serialisable](https://crystal-lang.org/api/0.27.2/IO.html#write_bytes%28object%2Cformat%3AIO%3A%3AByteFormat%3DIO%3A%3AByteFormat%3A%3ASystemEndian%29-instance-method)
 3. Bit Fields

--- a/spec/bindata_spec.cr
+++ b/spec/bindata_spec.cr
@@ -35,4 +35,19 @@ describe BinData do
 
     io2.to_slice.should eq(io.to_slice)
   end
+
+  it "should allow mixed endianess" do
+    io = IO::Memory.new
+    io.write_bytes 0xBE_i16, IO::ByteFormat::BigEndian
+    io.write_bytes 0xFEED_i32, IO::ByteFormat::LittleEndian
+    io.write_bytes 0xDADFEDBEEF_i128, IO::ByteFormat::LittleEndian
+    io.rewind
+
+    r = MixedEndianLittle.new
+    r.read io
+
+    r.big.should eq(0xBE_i16)
+    r.little.should eq(0xFEED_i32)
+    r.default.should eq(0xDADFEDBEEF_i128)
+  end
 end

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -135,3 +135,12 @@ class ObjectIdentifier < BinData
     bits 22, :instance_number
   end
 end
+
+class MixedEndianLittle < BinData
+  endian :little
+
+  int16be :big
+  int32le :little
+
+  int128 :default
+end


### PR DESCRIPTION
I'm dealing with BLE data a lot and in many cases vendors are using mixed endianess in a single frame.

This PR adds DSL methods to specify endianess on a field level: 

```crystal
class SensorData < BinData
   int32le :temperature
   uint16be :humidity
end
```