### PR TITLE
`custom` property name set incorrectly, when helper is used

### DIFF
--- a/spec/bindata_group_spec.cr
+++ b/spec/bindata_group_spec.cr
@@ -14,8 +14,8 @@ describe BinData do
     r = Wow.new
     r.read io
     r.start.should eq(0_u8)
-    r.header.size.should eq(5)
-    r.header.name.should eq("hello")
+    r.head.size.should eq(5)
+    r.head.name.should eq("hello")
     r.body.start.should eq(1_u8)
     r.body.end.should eq(3_u8)
     r.end.should eq(0_u8)
@@ -31,8 +31,8 @@ describe BinData do
     r = Wow.new
     r.read io
     r.start.should eq(0_u8)
-    r.header.size.should eq(0)
-    r.header.name.should eq("")
+    r.head.size.should eq(0)
+    r.head.name.should eq("")
     r.body.start.should eq(0)
     r.body.end.should eq(0)
     r.end.should eq(0_u8)
@@ -49,8 +49,8 @@ describe BinData do
     io.rewind
 
     r = Wow.new
-    r.header = Header.new
-    r.header.name = "whatwhat"
+    r.head = Header.new
+    r.head.name = "whatwhat"
 
     io2 = IO::Memory.new
     r.write(io2)

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -35,9 +35,9 @@ class Wow < BinData
   endian big
 
   uint8 :start, value: ->{ 0_u8 }
-  header :header
+  header :head
 
-  group :body, onlyif: ->{ header.size > 0 } do
+  group :body, onlyif: ->{ head.size > 0 } do
     uint8 :start, value: ->{ 1_u8 }, onlyif: ->{ parent.start == 0 }
     uint8 :end, value: ->{ 3_u8 }
   end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -22,7 +22,7 @@ abstract class BinData
     {% method_name = custom_type.gsub(/::/, "_").underscore.id %}
       {% unless RESERVED_NAMES.includes? method_name.stringify %}
         macro {{ method_name }}(name, onlyif = nil, verify = nil, value = nil)
-          custom {{method_name}} : {{custom_type}} = {{ custom_type }}.new
+          custom \{{name.id}} : {{custom_type}} = {{ custom_type }}.new
         end
       {% end %}
     {% end %}


### PR DESCRIPTION
```
class NiceType < BinData
end

class Bar < BinDara
   nice_type :baz
end

```

My little typo would generate `Bar#nice_type` instead of `Bar#baz` 😬