### PR TITLE
fix(asn1): encode/decode OID sub-identifiers as base-128 (X.690 §8.19)

### DIFF
--- a/spec/bindata_asn1_spec.cr
+++ b/spec/bindata_asn1_spec.cr
@@ -187,4 +187,86 @@ describe ASN1 do
     # io = IO::Memory.new(b)
     # io.read_bytes(ASN1::BER).get_bitstring.should eq(Bytes[0x0, 0xF])
   end
+
+  # --- Object Identifier: base-128 multi-byte sub-identifiers (X.690 §8.19) ---
+  # Audit Tier 0.1 / 0.2 — large arcs were silently corrupted / overflowed.
+
+  it "writes an OID whose arc needs 3 base-128 bytes (RSA: 1.2.840.113549.1.1.1)" do
+    # 42=0x2a ; 840=0x86 0x48 ; 113549=0x86 0xf7 0x0d ; 1 1 1
+    goal = Bytes[6, 9, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 1, 1, 1]
+    test = ASN1::BER.new
+    test.set_object_id "1.2.840.113549.1.1.1"
+
+    io = IO::Memory.new
+    io.write_bytes(test)
+    io.to_slice.should eq(goal)
+  end
+
+  it "reads an OID whose arc needs 3 base-128 bytes (RSA: 1.2.840.113549.1.1.1)" do
+    b = Bytes[6, 9, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 1, 1, 1]
+    io = IO::Memory.new(b)
+    io.read_bytes(ASN1::BER).get_object_id.should eq("1.2.840.113549.1.1.1")
+  end
+
+  it "round-trips a large first sub-identifier under joint-iso-itu-t (2.999.3)" do
+    # first=2, second=999 -> Y0 = 40*2 + 999 = 1079 = 0x88 0x37
+    goal = Bytes[6, 3, 0x88, 0x37, 3]
+    test = ASN1::BER.new
+    test.set_object_id "2.999.3"
+
+    io = IO::Memory.new
+    io.write_bytes(test)
+    io.to_slice.should eq(goal)
+
+    io.rewind
+    io.read_bytes(ASN1::BER).get_object_id.should eq("2.999.3")
+  end
+
+  it "round-trips an arc larger than UInt64 (UUID-based OID, ITU-T X.667)" do
+    oid = "2.25.340282366920938463463374607431768211455" # 2.25.(2**128 - 1)
+    test = ASN1::BER.new
+    test.set_object_id oid
+
+    io = IO::Memory.new
+    io.write_bytes(test)
+    io.rewind
+    io.read_bytes(ASN1::BER).get_object_id.should eq(oid)
+  end
+
+  it "round-trips the first-sub-identifier boundary arcs (X = 0/1/2)" do
+    {
+      "1.39" => Bytes[6, 1, 0x4f],       # 40 + 39 = 79
+      "2.0"  => Bytes[6, 1, 0x50],       # 80
+      "2.47" => Bytes[6, 1, 0x7f],       # 80 + 47 = 127, last single-octet value
+      "2.48" => Bytes[6, 2, 0x81, 0x00], # 128, first value needing two octets
+    }.each do |oid, goal|
+      test = ASN1::BER.new
+      test.set_object_id oid
+      io = IO::Memory.new
+      io.write_bytes(test)
+      io.to_slice.should eq(goal)
+
+      io.rewind
+      io.read_bytes(ASN1::BER).get_object_id.should eq(oid)
+    end
+  end
+
+  it "reads an empty object identifier payload as an empty string" do
+    io = IO::Memory.new(Bytes[6, 0])
+    io.read_bytes(ASN1::BER).get_object_id.should eq("")
+  end
+
+  it "rejects malformed object identifiers" do
+    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("3.1.1") } # first arc > 2
+    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("0.40") }  # first < 2, second >= 40
+    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("1.40") }  # first < 2, second >= 40
+    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("1.-1") }  # negative arc
+    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("1.x") }   # non-numeric arc
+  end
+
+  it "rejects a payload truncated mid sub-identifier (trailing continuation bit)" do
+    # 0x2a decodes fine (42), 0x86 sets the continuation bit but no octet follows.
+    io = IO::Memory.new(Bytes[6, 2, 0x2a, 0x86])
+    expect_raises(ASN1::BER::InvalidObjectId) { io.read_bytes(ASN1::BER).get_object_id }
+  end
 end

--- a/src/bindata/asn1/data_types.cr
+++ b/src/bindata/asn1/data_types.cr
@@ -1,3 +1,5 @@
+require "big"
+
 class ASN1::BER < BinData
   class InvalidTag < Exception; end
 
@@ -42,69 +44,90 @@ class ASN1::BER < BinData
     raise InvalidTag.new("object is a #{tag}, expecting #{check_tag}") unless tag == check_tag
   end
 
-  # Returns the object ID in string format
+  # Returns the object ID in string format.
+  #
+  # Sub-identifiers are decoded as big-endian base-128 numbers per X.690 §8.19
+  # (every octet but the last has its high bit set), so arcs of any size are
+  # supported. `BigInt` is used because OID arcs are unbounded (e.g. UUID-based
+  # OIDs under `2.25`, ITU-T X.667).
   def get_object_id
     ensure_universal(UniversalTags::ObjectIdentifier)
     return "" if @payload.size == 0
 
-    value0 = @payload[0].to_i32
-    second = value0 % 40
-    first = (value0 - second) // 40
-    raise InvalidObjectId.new(@payload.inspect) if first > 2
-    object_id = [first, second]
-
-    # Some crazy shit going on here: https://docs.microsoft.com/en-us/windows/desktop/seccertenroll/about-object-identifier
-    n = 0
-    (1...@payload.size).each do |i|
-      if @payload[i] > 0x80 && n == 0
-        n = (@payload[i].to_i32 & 0x7f) << 8
-      elsif n > 0
-        # We need to ignore the high bit of the 2nd byte
-        n = n + (@payload[i] << 1)
-        object_id << (n >> 1)
-        n = 0
-      else
-        object_id << @payload[i].to_i32
+    # Decode the payload into its base-128 sub-identifiers. This is BER-permissive
+    # and does not reject non-minimal encodings (a leading 0x80 octet), which
+    # X.690 §8.19.2 forbids for DER but which decode unambiguously.
+    sub_ids = [] of BigInt
+    value = BigInt.new(0)
+    pending = false
+    @payload.each do |byte|
+      value = value * 128 + (byte & 0x7f)
+      pending = true
+      if (byte & 0x80) == 0
+        sub_ids << value
+        value = BigInt.new(0)
+        pending = false
       end
     end
+    # A trailing continuation bit means the OID was truncated mid sub-identifier.
+    raise InvalidObjectId.new(@payload.inspect) if pending
 
-    object_id.join(".")
+    # The first sub-identifier encodes the first two arcs: Y0 = 40 * X + Y,
+    # with X capped at 2 (X = 2 absorbs any second arc, which may be large).
+    first_sub = sub_ids.first
+    if first_sub < 80
+      arcs = [first_sub // 40, first_sub % 40]
+    else
+      arcs = [BigInt.new(2), first_sub - 80]
+    end
+    arcs.concat(sub_ids[1..])
+
+    arcs.join(".")
   end
 
-  # Sets a string representing an object ID
+  # Sets a string representing an object ID.
+  #
+  # Each arc is encoded as a big-endian base-128 number per X.690 §8.19. Arcs
+  # are parsed as `BigInt`, so arbitrarily large values are supported.
   def set_object_id(oid)
-    value = oid.split(".").map &.to_i
-
-    raise InvalidObjectId.new(value.inspect) if value.size < 1
-    raise InvalidObjectId.new(value.inspect) if value[0] > 2
-
-    # Set the appropriate tags
-    self.tag_class = TagClass::Universal
-    self.tag_number = UniversalTags::ObjectIdentifier
-    data = IO::Memory.new
-
-    # Convert the string to bytes
-    if value.size > 1
-      raise InvalidObjectId.new(value.inspect) if value[0] < 2 && value[1] > 40
-      # First two parts are combined
-      data.write_byte (40 * value[0] + value[1]).to_u8
-      (2...value.size).each do |i|
-        if value[i] < 0x80
-          data.write_byte(value[i].to_u8)
-        else
-          # Parts bigger than 128 are represented by 2 bytes (14 usable bits)
-          bytes = value[i] << 1
-          data.write_byte (((bytes & 0xFF00) >> 8) | 0x80).to_u8
-          data.write_byte ((bytes & 0xFF) >> 1).to_u8
-        end
-      end
-    else
-      data.write_byte((40 * value[0]).to_u8)
+    # `BigInt.new` rejects non-numeric / empty arcs.
+    arcs = begin
+      oid.split(".").map { |part| BigInt.new(part) }
+    rescue ArgumentError
+      raise InvalidObjectId.new(oid)
     end
 
+    raise InvalidObjectId.new(oid) if arcs.empty?
+    raise InvalidObjectId.new(oid) if arcs.any?(&.negative?)
+    raise InvalidObjectId.new(oid) if arcs[0] > 2
+    raise InvalidObjectId.new(oid) if arcs.size > 1 && arcs[0] < 2 && arcs[1] >= 40
+
+    self.tag_class = TagClass::Universal
+    self.tag_number = UniversalTags::ObjectIdentifier
+
+    data = IO::Memory.new
+    if arcs.size > 1
+      # The first two arcs are combined into a single sub-identifier.
+      write_oid_sub_id(data, arcs[0] * 40 + arcs[1])
+      arcs[2..].each { |arc| write_oid_sub_id(data, arc) }
+    else
+      write_oid_sub_id(data, arcs[0] * 40)
+    end
     @payload = data.to_slice
 
     self
+  end
+
+  # Writes a single OID sub-identifier as a big-endian base-128 number, setting
+  # the high (continuation) bit on every octet except the last.
+  private def write_oid_sub_id(io : IO, value : BigInt) : Nil
+    septets = [(value % 128).to_u8]
+    value //= 128
+    while value > 0
+      septets << ((value % 128).to_u8 | 0x80_u8)
+      value //= 128
+    end
+    septets.reverse_each { |byte| io.write_byte(byte) }
   end
 
   # Gets a hex representation of the bytes


### PR DESCRIPTION
## What

Rewrites the ASN.1 OID (Object Identifier) encoder/decoder to use proper X.690
§8.19 base-128 sub-identifier encoding, replacing a bespoke 2-byte scheme.

Fixes audit tier **0.1 / 0.2** from #18.

## Why

The previous codec only handled 2-byte sub-identifiers (≤ 14 bits), so:

- **Silent corruption** of any arc ≥ 16384 — including the ubiquitous RSA/PKCS
  OID `1.2.840.113549.1.1.1`, which round-tripped to `1.2.840.15245.1.1.1`
  (the `113549` arc lost a byte) with no error.
- **`OverflowError`** for a large first sub-identifier under `joint-iso-itu-t`
  (first arc `2`), e.g. `2.999.x` (`40*2 + 999 = 1079` overflowed `UInt8`).

Both stem from the same cause, so the whole codec is fixed rather than the two
symptoms. The behaviour now matches X.690 §8.19 (and the very Microsoft
reference the old code cited but misread).

## How

- `get_object_id` / `set_object_id` decode/encode each sub-identifier as a
  big-endian base-128 number with the high (continuation) bit set on every octet
  but the last.
- Arcs are parsed/accumulated as `BigInt` (`require "big"`), so arbitrarily large
  arcs are supported — e.g. UUID-based OIDs under `2.25` (ITU-T X.667).
- Malformed inputs now raise the existing `InvalidObjectId` instead of crashing
  with `OverflowError` / `ArgumentError`: non-numeric / empty / negative arcs,
  first arc > 2, second arc ≥ 40 under roots 0/1 (this also fixes an off-by-one:
  the old check was `> 40`), and payloads truncated mid sub-identifier.
- The decoder is intentionally **BER-permissive**: it does not reject non-minimal
  encodings (a leading `0x80` octet) that X.690 §8.19.2 forbids only for DER.

## Tests

New `spec/bindata_asn1_spec.cr` cases (TDD, red first): the RSA OID read+write,
`2.999.3` round-trip, a `> UInt64` UUID-OID round-trip, the first-sub-identifier
boundary arcs (`1.39` / `2.0` / `2.47` / `2.48`), an empty payload, a truncated
payload, and malformed inputs. Full suite green (58 examples), `crystal tool
format --check` clean, no new `ameba` findings on the touched file.

## Known minor (out of scope here)

A single-arc input is asymmetric: `set_object_id("2")` encodes to `0x50`, which
`get_object_id` decodes back to `"2.0"` (a lone sub-identifier always decodes to
two arcs). This is not a regression — the previous code encoded it the same way
— and a complete OID has ≥ 2 arcs (X.660). Left as-is for this focused fix; happy
to reject single-arc OIDs in a follow-up if preferred.
