### PR TITLE
fix(macro): allow `value:` procs on Float (and other non-integer) fields

### DIFF
--- a/spec/bindata_value_spec.cr
+++ b/spec/bindata_value_spec.cr
@@ -1,0 +1,54 @@
+require "./helper"
+
+# Audit Tier 0.3 — a `value:` proc on a Float field used to fail to compile
+# (`undefined method '|' for Float64`), because the write-path coercion assumed
+# an integer type. Floats are now built directly, integers keep width coercion,
+# and any other basic type is assigned as-is.
+
+# A minimal IO-serializable custom type, to exercise the non-numeric "basic"
+# branch (assigned as-is, not coerced through `.new(0) | value`).
+struct Celsius
+  getter value : Int8
+
+  def initialize(@value : Int8 = 0_i8)
+  end
+
+  def self.from_io(io : IO, format : IO::ByteFormat) : Celsius
+    Celsius.new(io.read_bytes(Int8, format))
+  end
+
+  def to_io(io : IO, format : IO::ByteFormat) : Nil
+    io.write_bytes(@value, format)
+  end
+end
+
+class FloatValueData < BinData
+  endian big
+
+  field f64 : Float64, value: -> { 1.5 }
+  field f32 : Float32, value: -> { 2.25_f32 }
+  field from_int64 : Float64, value: -> { 3 }                          # Int proc, coerced to Float64
+  field from_int32 : Float32, value: -> { 3 }                          # Int proc, coerced to Float32
+  field negative : Float64, value: -> { -7.5 }                         # negative float
+  field counter : UInt16, value: -> { 7_u16 }                          # integer path must keep working
+  field temp : Celsius = Celsius.new, value: -> { Celsius.new(20_i8) } # custom "else" branch
+  field little : Float64, value: -> { 6.5 }, endian: IO::ByteFormat::LittleEndian
+end
+
+describe "value: proc coercion" do
+  it "supports Float fields with a value proc (Tier 0.3)" do
+    io = IO::Memory.new
+    io.write_bytes(FloatValueData.new)
+    io.rewind
+
+    rt = io.read_bytes(FloatValueData)
+    rt.f64.should eq(1.5)
+    rt.f32.should eq(2.25_f32)
+    rt.from_int64.should eq(3.0)
+    rt.from_int32.should eq(3.0_f32)
+    rt.negative.should eq(-7.5)
+    rt.counter.should eq(7_u16)
+    rt.temp.value.should eq(20_i8)
+    rt.little.should eq(6.5)
+  end
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -275,10 +275,19 @@ abstract class BinData
           {% if part[:value] %}
             # check if we need to configure the value
             %value = ({{part[:value]}}).call
-            # This ensures numbers are cooerced to the correct type
+            # This coerces the proc's result to the field's type. Integers use
+            # `| value` to coerce width; floats can't (no bitwise `|`), so they
+            # are built directly; any other basic type is assigned as-is.
             # NOTE:: `if %value.is_a?(Number)` had issues with `String` due to `.new(0)`
             {% if part[:type] == "basic" %}
-              @{{part[:name]}} = {{part[:cls]}}.new(0) | %value
+              {% basic_type = part[:cls].resolve %}
+              {% if basic_type == Float32 || basic_type == Float64 %}
+                @{{part[:name]}} = {{part[:cls]}}.new(%value)
+              {% elsif {Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128}.includes?(basic_type) %}
+                @{{part[:name]}} = {{part[:cls]}}.new(0) | %value
+              {% else %}
+                @{{part[:name]}} = %value
+              {% end %}
             {% else %}
               @{{part[:name]}} = %value || @{{part[:name]}}
             {% end %}


### PR DESCRIPTION
## What

Lets a `value:` proc be used on `Float32`/`Float64` fields (and any other
non-integer basic field). Fixes audit tier **0.3** from #18.

## Why

In the write path, a field with a `value:` proc coerced the proc's result with
`{{cls}}.new(0) | %value`. The `|` (bitwise-or) only exists on integers, so a
`value:` proc on a float field failed to **compile**:

```crystal
field x : Float64, value: -> { 1.5 }
# Error: undefined method '|' for Float64
```

## How

The coercion now branches on the resolved basic type (`part[:cls].resolve`,
the same `.resolve` already used a few lines below for the union check):

- **integer** (`Int8`…`UInt128`) → unchanged: `{{cls}}.new(0) | %value` (width coercion);
- **float** (`Float32`/`Float64`) → `{{cls}}.new(%value)` (also coerces an `Int` the proc may return);
- **any other basic type** → `%value` as-is (the old `.new(0) | %value` could never have compiled for these).

This is centralized at the one coercion site, so it also covers the deprecated
`float32`/`float64`/`…be`/`…le` macros.

## Tests

New `spec/bindata_value_spec.cr` (TDD, red first — it was a compile error): a
`Float64` and `Float32` value proc, an `Int`-returning proc coerced to each
float width, a negative float, a little-endian float field, an integer
non-regression, and a non-numeric custom `BinData`-serializable type to exercise
the "assigned as-is" branch. Full suite green (59 examples), `crystal tool
format --check` clean, no new `ameba` findings on `src/bindata.cr`.

> Note: I did not add a spec exercising the deprecated `float64`/`float64be`
> macros with a `value:` proc — it would emit deprecation warnings into the
> otherwise warning-free suite. The fix covers them via the same code path.
