### PR TITLE
fix(macro): reserve DSL macro/method names from per-type shortcut generation

### DIFF
--- a/spec/bindata_reserved_names_spec.cr
+++ b/spec/bindata_reserved_names_spec.cr
@@ -1,0 +1,86 @@
+require "./helper"
+
+# Audit Tier 0.4 — the `inherited` hook generates a shortcut macro named after
+# every BinData subclass. A subclass whose underscored name matches a DSL macro
+# (e.g. `Field` -> `field`) used to clobber that macro globally, breaking the
+# DSL for every class defined afterwards.
+#
+# These empty subclasses have names that collide with DSL macros / API methods.
+# Defining them must NOT generate clobbering shortcut macros.
+class Field < BinData
+  endian big
+end
+
+class Bits < BinData
+  endian big
+end
+
+class Endian < BinData
+  endian big
+end
+
+class Group < BinData
+  endian big
+end
+
+class Custom < BinData
+  endian big
+end
+
+# Defined AFTER the colliding types above: this only compiles if `endian`,
+# `field`, `bit_field`, `bits`, `bool` and `group` were left intact.
+class StillWorks < BinData
+  endian big
+
+  field x : UInt8 = 0x11_u8
+
+  bit_field do
+    bits 4, hi
+    bool flag
+    bits 3, lo
+  end
+
+  group :grp do
+    field z : UInt8 = 0x22_u8
+  end
+end
+
+# A namespaced type underscores to `reserved_names_field` (not `field`), so it
+# must never collide with the DSL regardless of its short name.
+module ReservedNames
+  class Field < BinData
+    endian big
+  end
+end
+
+class StillWorksNamespaced < BinData
+  endian big
+  field q : UInt8 = 0x33_u8
+end
+
+describe "reserved DSL macro names" do
+  it "keeps the DSL intact after colliding type names are defined (Tier 0.4)" do
+    data = StillWorks.new
+    data.x.should eq(0x11_u8)
+    data.grp.z.should eq(0x22_u8)
+
+    data.hi = 0xa_u8
+    data.flag = true
+    data.lo = 0x5_u8
+
+    io = IO::Memory.new
+    io.write_bytes(data)
+    io.rewind
+
+    rt = io.read_bytes(StillWorks)
+    rt.x.should eq(0x11_u8)
+    rt.hi.should eq(0xa_u8)
+    rt.flag.should eq(true)
+    rt.lo.should eq(0x5_u8)
+    rt.grp.z.should eq(0x22_u8)
+  end
+
+  it "does not collide for namespaced type names" do
+    StillWorksNamespaced.new.q.should eq(0x33_u8)
+  end
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -2,11 +2,33 @@ require "./bindata/exceptions"
 require "./bindata/bitfield"
 
 abstract class BinData
-  INDEX          = [-1]
-  BIT_PARTS      = [] of Nil
-  CUSTOM_TYPES   = [] of BinData.class
-  RESERVED_NAMES = ["inherited", "included", "extended", "method_missing",
-                    "method_added", "finished"]
+  INDEX        = [-1]
+  BIT_PARTS    = [] of Nil
+  CUSTOM_TYPES = [] of BinData.class
+  # Names the per-type shortcut macro (generated in `inherited`) must never take,
+  # otherwise defining a subclass whose underscored name matches one of these
+  # would clobber a Crystal hook, a DSL macro, or a public method globally.
+  #
+  # NOTE: when adding a new DSL macro to this class, add its name here too,
+  # otherwise a subclass named after it will silently clobber it.
+  RESERVED_NAMES = [
+    # Crystal hooks / object protocol
+    "inherited", "included", "extended", "method_missing", "method_added", "finished",
+    "new", "inspect",
+    # public (de)serialization API
+    "read", "write", "to_io", "from_io", "to_slice", "from_slice", "to_s", "bit_fields", "parent",
+    # DSL macros
+    "endian", "field", "bits", "enum_bits", "bool", "bit_field", "group",
+    "remaining_bytes", "before_serialize", "after_deserialize",
+    "custom", "enum_field", "array", "variable_array", "string", "bytes",
+    # deprecated per-type field macros (uintN / intN / floatN and their be/le forms)
+    "uint8", "uint8be", "uint8le", "int8", "int8be", "int8le",
+    "uint16", "uint16be", "uint16le", "int16", "int16be", "int16le",
+    "uint32", "uint32be", "uint32le", "int32", "int32be", "int32le",
+    "uint64", "uint64be", "uint64le", "int64", "int64be", "int64le",
+    "uint128", "uint128be", "uint128le", "int128", "int128be", "int128le",
+    "float32", "float32be", "float32le", "float64", "float64be", "float64le",
+  ]
 
   macro inherited
     PARTS = [] of Nil


### PR DESCRIPTION
## What

Stops a BinData subclass from clobbering the DSL by naming it after a DSL
macro. Fixes audit tier **0.4** from #18.

## Why

The `inherited` hook generates, for every subclass, a shortcut macro named after
the type (`Header` → `header`, so you can write `header :name`). The guard against
collisions was a 6-entry `RESERVED_NAMES`, so a subclass whose underscored name
matched a DSL macro overrode it **globally**:

```crystal
class Field < BinData; end
class Packet < BinData
  field x : UInt8   # Error: unexpected token: ":"  — `field` was clobbered
end
```

For the deprecated per-type numeric macros this is worse — it **silently
miscompiles** rather than erroring: `class Uint8 < BinData` makes `uint8 :v`
declare a field typed as the `Uint8` subclass instead of `UInt8`.

## How

`RESERVED_NAMES` now lists every name the generated shortcut must not take:
all DSL macros, the deprecated `uintN`/`intN`/`floatN` (+ `be`/`le`) macros, and
the public (de)serialization methods (`read`/`write`/`to_io`/`from_io`/… plus
`new`/`inspect`/`parent`). A subclass named after any of these simply gets no
shortcut macro (you can still use the explicit `field x : Field = Field.new`).

The list is a hand-maintained denylist — Crystal has no macro-time way to ask
"does a macro named X already exist" — so a comment instructs future DSL-macro
authors to keep it in sync.

## Tests

New `spec/bindata_reserved_names_spec.cr` (TDD, red first — it failed to compile
on `master`): defines empty subclasses whose names collide (`Field`, `Bits`,
`Endian`, `Group`, `Custom`), then a class using `endian`/`field`/`bit_field`/
`bits`/`bool`/`group` and round-trips it; plus a namespaced type
(`ReservedNames::Field` → `reserved_names_field`) confirming `::`→`_` avoids
collisions. Full suite green (60 examples), `crystal tool format --check` clean,
no new `ameba` findings on `src/bindata.cr`.

> Note: I did not add a unit test for the deprecated-numeric collision
> (`class Uint8` + `uint8 :v`) — it would emit a deprecation warning into the
> otherwise warning-free suite. The reservation covers it.
