### PR TITLE
fix(asn1): cap BER content length to guard read against allocation DoS

### DIFF
--- a/spec/bindata_asn1_dos_spec.cr
+++ b/spec/bindata_asn1_dos_spec.cr
@@ -1,0 +1,65 @@
+require "./helper"
+
+# Audit Tier 0.5 — BER#read trusts the declared length before reading, so a tiny
+# hostile message can force a ~2 GiB allocation or an unbounded read. An opt-in
+# per-instance `max_content_length` cap guards every allocation site, and the cap
+# propagates into `children` so a small frame cannot smuggle an oversized child.
+
+private def read_capped(bytes : Bytes, cap : Int32) : ASN1::BER
+  ber = ASN1::BER.new
+  ber.max_content_length = cap
+  ber.read(IO::Memory.new(bytes))
+  ber
+end
+
+describe "ASN1::BER max_content_length" do
+  it "defaults to 0 (unlimited), leaving existing behaviour unchanged" do
+    ASN1::BER.new.max_content_length.should eq(0)
+
+    # A normal frame read via the usual API is unaffected.
+    ber = IO::Memory.new(Bytes[0x04, 0x03, 1, 2, 3]).read_bytes(ASN1::BER)
+    ber.payload.should eq(Bytes[1, 2, 3])
+  end
+
+  it "rejects a definite length larger than the cap before allocating" do
+    # OctetString, long-form length 0x7FFFFFFF (~2 GiB), no payload follows.
+    header = Bytes[0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(ASN1::BER::ContentTooLarge) { read_capped(header, 1024) }
+  end
+
+  it "bounds an indefinite-length value with no terminator" do
+    # Indefinite length (0x80) followed by non-zero bytes that never reach 00 00.
+    data = Bytes.new(64, 0x01_u8)
+    data[0] = 0x24_u8 # constructed
+    data[1] = 0x80_u8 # indefinite length
+    expect_raises(ASN1::BER::ContentTooLarge) { read_capped(data, 16) }
+  end
+
+  it "propagates the cap into children (no amplification)" do
+    # 8-byte SEQUENCE whose 6-byte payload nests a child announcing ~2 GiB.
+    frame = Bytes[0x30, 0x06, 0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF]
+    root = read_capped(frame, 1024) # the outer frame is small, so this succeeds
+    expect_raises(ASN1::BER::ContentTooLarge) { root.children }
+  end
+
+  it "reads a normal frame that fits within the cap" do
+    ber = read_capped(Bytes[0x04, 0x03, 1, 2, 3], 1024)
+    ber.payload.should eq(Bytes[1, 2, 3])
+  end
+
+  it "allows a length exactly equal to the cap (inclusive boundary)" do
+    ber = read_capped(Bytes[0x04, 0x03, 1, 2, 3], 3)
+    ber.payload.should eq(Bytes[1, 2, 3])
+  end
+
+  it "accepts an empty payload" do
+    read_capped(Bytes[0x04, 0x00], 1024).payload.should be_empty
+  end
+
+  it "propagates the cap to grandchildren" do
+    # SEQUENCE { SEQUENCE { OCTET STRING announcing ~2 GiB } }
+    frame = Bytes[0x30, 0x08, 0x30, 0x06, 0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF]
+    child = read_capped(frame, 1024).children.first
+    expect_raises(ASN1::BER::ContentTooLarge) { child.children }
+  end
+end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -12,10 +12,24 @@ module ASN1
   class BER < BinData
     endian big
 
+    # Raised when a declared content length exceeds `max_content_length`.
+    class ContentTooLarge < Exception
+    end
+
     # Components of a BER object
     field identifier : Identifier = Identifier.new
     field length : Length = Length.new
     property payload : Bytes = Bytes.new(0)
+
+    # Maximum number of payload bytes this object (and its children) may
+    # allocate or read. `0`, the default, means unlimited. Set a positive cap
+    # before reading untrusted input to guard against allocation/exhaustion DoS,
+    # reading the root explicitly so the cap is in place before parsing:
+    #
+    #     ber = ASN1::BER.new
+    #     ber.max_content_length = 64 * 1024
+    #     ber.read(io)
+    property max_content_length : Int32 = 0
 
     def tag_class
       @identifier.tag_class
@@ -72,6 +86,7 @@ module ASN1
           current_byte = io.read_byte.not_nil!
           break if previous_byte == 0_u8 && current_byte == 0_u8
           temp.write_byte previous_byte
+          ensure_content_length(temp.pos)
           previous_byte = current_byte
         end
 
@@ -79,6 +94,8 @@ module ASN1
         temp.rewind
         temp.read_fully(@payload)
       else
+        # Guard before allocating: the declared length is attacker-controlled.
+        ensure_content_length(@length.length)
         begin
           @payload = Bytes.new(@length.length)
           io.read_fully(@payload)
@@ -88,6 +105,13 @@ module ASN1
         end
       end
       io
+    end
+
+    private def ensure_content_length(size)
+      return if @max_content_length <= 0
+      if size > @max_content_length
+        raise ContentTooLarge.new("ASN.1 content length #{size} exceeds max_content_length #{@max_content_length}")
+      end
     end
 
     def write(io : IO)
@@ -110,7 +134,11 @@ module ASN1
       parts = [] of BER
       io = IO::Memory.new(@payload)
       while io.pos < io.size
-        parts << io.read_bytes(ASN1::BER)
+        # Propagate the cap so a small frame can't smuggle an oversized child.
+        child = BER.new
+        child.max_content_length = @max_content_length
+        child.read(io)
+        parts << child
       end
       parts
     end


### PR DESCRIPTION
## What

Adds an opt-in per-instance content-length cap to `ASN1::BER`, guarding the read
path against an allocation/exhaustion DoS. Addresses audit tier **0.5** from #18.

## Why

`ASN1::BER#read` trusted the declared length *before* reading any payload, so a
tiny hostile message could:

- **definite length** — force `Bytes.new(@length.length)` to allocate up to
  ~2 GiB before `read_fully`. A 6-byte header (`04 84 7F FF FF FF`) is enough.
- **indefinite length** — loop until `00 00`, growing without bound if the
  terminator never arrives.
- **amplify via `children`** — each child was re-parsed with no limit, so a
  ~50-byte message could nest a child announcing 2 GiB. Bounding the outer frame
  was not enough.

## How

- New `property max_content_length : Int32 = 0` (`0` = unlimited → existing
  users unchanged).
- A private `ensure_content_length` guard runs **before** every payload
  allocation: before `Bytes.new` in the definite branch, and **per iteration**
  in the indefinite loop (bails on the first over-cap byte).
- `children` now sets `child.max_content_length = @max_content_length` before
  reading each child, so the cap **propagates recursively** (grandchildren too).
- Breaches raise a typed `ASN1::BER::ContentTooLarge` (consistent with the
  module's other `< Exception` errors, `InvalidTag` / `InvalidObjectId`).

Because `io.read_bytes(ASN1::BER)` / `from_io` construct then read (so they
can't set the cap before parsing), set the cap by reading the root explicitly:

```crystal
ber = ASN1::BER.new
ber.max_content_length = 64 * 1024
ber.read(io)
```

## Tests

New `spec/bindata_asn1_dos_spec.cr` (TDD, red first): default-unlimited keeps old
behaviour; definite length over the cap raises before allocating; indefinite
length with no terminator is bounded; child amplification is blocked; the cap
propagates to grandchildren; the `cap == length` inclusive boundary is allowed;
an empty payload is accepted. Full suite green (66 examples), also under
`-Dpreview_mt`; `crystal tool format --check` clean; no new `ameba` findings on
`src/bindata/asn1.cr`.

## Out of scope (follow-up)

Reviewer flagged a separate, smaller unbounded-allocation vector that this cap
does not cover: `Identifier#read` (`src/bindata/asn1/identifier.cr:37-42`) loops
appending `ExtendedIdentifier`s while the continuation bit is set, with no limit.
It's the same exhaustion class but has no length-field amplification (~1x, bounded
by input size) and `Identifier` has no access to the `BER` cap, so it needs a
distinct fixed limit. Happy to send a focused follow-up PR for it — left out here
to keep this change scoped to the content-length DoS.
