### PR TITLE
fix(bitfield): make BitField fiber-safe by removing shared mutable state

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,3 +30,7 @@ jobs:
       run: crystal tool format --check
     - name: Run tests
       run: crystal spec -v --error-trace
+    - name: Run tests (multi-threaded)
+      run: crystal spec -v --error-trace -Dpreview_mt
+      env:
+        CRYSTAL_WORKERS: "4"

--- a/spec/bindata_fiber_safety_spec.cr
+++ b/spec/bindata_fiber_safety_spec.cr
@@ -1,0 +1,84 @@
+require "./helper"
+
+# Audit Tier 2.1 — the per-class `BitField` was a singleton mutated in place
+# during read/write (`@buffer`, `@values`). Two fibers (de)serializing instances
+# of the same class concurrently raced on that shared state, corrupting values
+# (and, under -Dpreview_mt, mutating a shared Hash from multiple threads).
+#
+# These stress tests only exercise the race under -Dpreview_mt (true parallelism);
+# in single-threaded mode the bitfield ops never yield, so they pass trivially.
+# The CI runs the suite under -Dpreview_mt so this stays a real regression guard.
+
+# Sub-byte and multi-byte fields exercise the buffer-`shift` path (historically
+# the most race-prone code), not just a byte-aligned read.
+class BitRace < BinData
+  endian big
+
+  bit_field do
+    bits 3, :a
+    bits 5, :b
+    bits 16, :c
+    bits 8, :d
+  end
+end
+
+private def stress(fiber_count : Int32, iterations : Int32, &block : Int32 -> Bool)
+  done = Channel(Int32).new
+  fiber_count.times do |f|
+    spawn do
+      mismatches = 0
+      iterations.times do
+        mismatches += 1 unless block.call(f)
+        Fiber.yield
+      end
+      done.send(mismatches)
+    end
+  end
+  total = 0
+  fiber_count.times { total += done.receive }
+  total
+end
+
+describe "BinData bitfield fiber-safety" do
+  it "round-trips a bitfield struct concurrently without corruption (Tier 2.1)" do
+    mismatches = stress(8, 5_000) do |f|
+      a = (f & 0x7).to_u8
+      b = ((f &* 5) & 0x1f).to_u8
+      c = ((f &* 9973) & 0xffff).to_u16
+      d = (f &* 71).to_u8!
+
+      obj = BitRace.new
+      obj.a = a
+      obj.b = b
+      obj.c = c
+      obj.d = d
+
+      io = IO::Memory.new
+      obj.write(io)
+      io.rewind
+      rt = io.read_bytes(BitRace)
+
+      rt.a == a && rt.b == b && rt.c == c && rt.d == d
+    end
+    mismatches.should eq(0)
+  end
+
+  it "round-trips ASN.1 BER concurrently (Identifier/Length bitfields)" do
+    mismatches = stress(8, 3_000) do |f|
+      tag = f % 30 # < 31, so no extended-identifier path
+      payload = Bytes[f.to_u8!, (f &* 2).to_u8!, (f &* 3).to_u8!]
+
+      ber = ASN1::BER.new
+      ber.tag_number = tag
+      ber.payload = payload
+
+      io = IO::Memory.new
+      ber.write(io)
+      io.rewind
+      rt = io.read_bytes(ASN1::BER)
+
+      rt.tag_number == tag && rt.payload == payload
+    end
+    mismatches.should eq(0)
+  end
+end

--- a/spec/bitfield_spec.cr
+++ b/spec/bitfield_spec.cr
@@ -16,10 +16,10 @@ describe BinData::BitField do
     bf.bits 23, :three
     bf.apply
 
-    bf.read(io, IO::ByteFormat::LittleEndian)
-    bf[:seven].should eq(0b1110111)
-    bf[:two].should eq(0b01)
-    bf[:three].should eq(0)
+    values = bf.read(io, IO::ByteFormat::LittleEndian)
+    values["seven"].should eq(0b1110111)
+    values["two"].should eq(0b01)
+    values["three"].should eq(0)
   end
 
   it "should parse an object from an IO" do

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -182,11 +182,11 @@ abstract class BinData
 
           {% elsif part[:type] == "bitfield" %}
             %bitfield = self.class.bit_fields["{{part[:cls]}}_{{part[:name]}}"]
-            %bitfield.read(io, %endian)
+            %values = %bitfield.read(io, %endian)
 
             # Apply the values (with their correct type)
             {% for name, value in BIT_PARTS[part[:name]] %}
-              %value = %bitfield[{{name.id.stringify}}]
+              %value = %values[{{name.id.stringify}}]
               @{{name}} = %value.as({{value[0]}})
             {% end %}
           {% end %}
@@ -326,16 +326,17 @@ abstract class BinData
           {% elsif part[:type] == "bitfield" %}
             # Apply any values
             %bitfield = self.class.bit_fields["{{part[:cls]}}_{{part[:name]}}"]
+            %values = {} of String => BinData::BitField::Value
             {% for name, value in BIT_PARTS[part[:name]] %}
               {% if value[1] %}
                 %value = ({{value[1]}}).call
                 @{{name}} = %value || @{{name}}
               {% end %}
 
-              %bitfield[{{name.id.stringify}}] = @{{name}}.not_nil!
+              %values[{{name.id.stringify}}] = @{{name}}.not_nil!
             {% end %}
 
-            %bitfield.write(io, %endian)
+            %bitfield.write(io, %endian, %values)
           {% end %}
 
           {% if part[:onlyif] %}

--- a/src/bindata/bitfield.cr
+++ b/src/bindata/bitfield.cr
@@ -1,12 +1,14 @@
 class BinData::BitField
+  alias Value = UInt8 | UInt16 | UInt32 | UInt64 | UInt128
+
+  # NOTE: a BitField holds only immutable layout (`@bitsize`/`@mappings`), set
+  # once at class-definition time. `read`/`write` keep no per-operation state, so
+  # the per-class instance can be shared across fibers safely.
   def initialize
     @bitsize = 0
     @mappings = {} of String => Int32
-    @values = {} of String => UInt8 | UInt16 | UInt32 | UInt64 | UInt128
     # 4 + 12  ==  2bytes
   end
-
-  @buffer : Bytes?
 
   def bits(size, name)
     raise "no support for structures larger than 128 bits" if size > 128
@@ -16,8 +18,6 @@ class BinData::BitField
 
   def apply
     raise "bit mappings must be divisible by 8" if @bitsize % 8 > 0
-    # Extra byte used when writing to IO
-    @buffer = Bytes.new(@bitsize // 8)
   end
 
   def shift(buffer, num_bits, start_byte = 0)
@@ -61,9 +61,11 @@ class BinData::BitField
     buffer
   end
 
-  def read(input, format) # ameba:disable Metrics/CyclomaticComplexity
-    # Fill the buffer
-    buffer = @buffer.not_nil!
+  def read(input, format) : Hash(String, Value) # ameba:disable Metrics/CyclomaticComplexity
+    # Per-operation state only: a fresh buffer and value map, so concurrent
+    # reads of the shared per-class BitField don't race.
+    values = {} of String => Value
+    buffer = Bytes.new(@bitsize // 8)
     input.read_fully(buffer)
 
     # TODO:: Check if we need to re-order the bytes
@@ -153,14 +155,14 @@ class BinData::BitField
       shift_by = size % 8
       shift(buffer, shift_by) if shift_by > 0
 
-      @values[name] = value
+      values[name] = value
     end
 
-    input
+    values
   end
 
   # ameba:disable Metrics/CyclomaticComplexity
-  def write(io, format)
+  def write(io, format, values : Hash(String, Value))
     # Fill the buffer
     bytes = (@bitsize // 8) + 1
     buffer = Bytes.new(bytes)
@@ -176,7 +178,7 @@ class BinData::BitField
       # The extra byte lets us easily write to the buffer
       # without overwriting existing bytes
       start_byte += 1 if offset != 0
-      value = @values[name]
+      value = values[name]
 
       # Make sure there is enough space to write the bits
       temp_size = case value
@@ -238,13 +240,5 @@ class BinData::BitField
     io.write(buffer[0, bytes - 1])
 
     0_i64
-  end
-
-  def []=(name, value)
-    @values[name.to_s] = value
-  end
-
-  def [](name)
-    @values[name.to_s]
   end
 end


### PR DESCRIPTION
## What

Makes `BinData::BitField` fiber-safe by removing the shared mutable state that
two concurrent (de)serializations raced on. Fixes audit tier **2.1** from #18.

## Why

`@@bit_fields` holds one `BitField` **per class**, configured once at class
definition. The generated read/write macros mutated that shared singleton in
place:

- `read` filled the shared `@buffer` and wrote results into the shared `@values`;
- the write macro wrote field values into the shared `@values` before `write`.

So two fibers (de)serializing instances of the **same** class concurrently raced
on `@buffer`/`@values` — corrupting values, and under `-Dpreview_mt` mutating a
shared `Hash` from multiple threads. This hits **every `ASN1::BER` object**,
whose `Identifier` and `Length` bitfields are read on each parse — i.e. any
networked ASN.1 consumer (LDAP/SNMP) that reads on one fiber while writing on
others is exposed.

A stress test reproduces it: on `master` under `-Dpreview_mt` the new spec
reports tens of thousands of mismatches (and can hang on the concurrent-`Hash`
corruption); single-threaded it passes trivially because the bitfield ops never
yield.

## How

`BitField` now keeps only **immutable layout** (`@bitsize`/`@mappings`, set once
via `bits`/`apply` at class-definition time):

- `read(input, format) : Hash(String, Value)` — returns a fresh value map built
  on a **local** buffer (no `@buffer`, no `@values`).
- `write(io, format, values)` — takes the values as a parameter.
- `@buffer`, `@values`, `[]`, `[]=` are removed; the generated macros now use a
  local `%values` hash.

The per-class instance is therefore only ever **read** during (de)serialization,
so it's safe to share across fibers — the fix is structural rather than a lock.

A `-Dpreview_mt` CI step is added so the regression can't recur.

## Tests

New `spec/bindata_fiber_safety_spec.cr`: 8 fibers × thousands of iterations
round-tripping (a) a bitfield struct with sub-byte/multi-byte fields (exercising
the buffer-`shift` path) and (b) `ASN1::BER` objects (the real `Identifier`/
`Length` path), asserting zero cross-fiber corruption. Green single-threaded and
under `-Dpreview_mt`; full suite 60 examples in both modes; `crystal tool format
--check` clean; `ameba` on `bitfield.cr` goes 4 → 3 (one `.not_nil!` removed).

## API / SemVer

`BinData::BitField` is internal machinery driven by the macros; the only direct
caller besides the macros was `spec/bitfield_spec.cr` (updated). Still, this
changes its public signatures (`read` return type, `write` arity, removal of
`[]`/`[]=`), so it warrants a **minor** version bump.
