### PR TITLE
fix(asn1): bound extended-identifier parsing against unbounded growth

### DIFF
--- a/spec/bindata_asn1_identifier_spec.cr
+++ b/spec/bindata_asn1_identifier_spec.cr
@@ -1,0 +1,54 @@
+require "./helper"
+
+# Follow-up to the Tier 0.5 DoS work: `Identifier#read` looped appending
+# `ExtendedIdentifier`s while the continuation bit was set, with no limit, so a
+# stream of `more`-flagged bytes (0xFF...) grew the array unbounded. A fixed cap
+# bounds it and raises a typed `InvalidTag`.
+#
+# Identifier byte 0x5F = tag_class Application, not constructed, tag_number 0b11111
+# (=> extended? is true). Extended bytes: high bit = `more`, low 7 = tag number.
+
+describe ASN1::BER::Identifier do
+  it "rejects an over-long extended identifier" do
+    bytes = Bytes[0x5F] + Bytes.new(20, 0xFF_u8) # 20 continuation bytes, never terminates
+    io = IO::Memory.new(bytes)
+    expect_raises(ASN1::BER::InvalidTag) { io.read_bytes(ASN1::BER::Identifier) }
+  end
+
+  it "reads a valid multi-byte extended identifier" do
+    io = IO::Memory.new(Bytes[0x5F, 0x81, 0x00]) # two extended bytes, second ends it
+    id = io.read_bytes(ASN1::BER::Identifier)
+    id.extended.size.should eq(2)
+    id.tag_number.should eq(0b11111_u8)
+  end
+
+  it "accepts exactly the maximum number of extended bytes" do
+    max = ASN1::BER::Identifier::MAX_EXTENDED_BYTES
+    bytes = Bytes[0x5F] + Bytes.new(max - 1, 0x81_u8) + Bytes[0x00] # max parts, last terminates
+    id = IO::Memory.new(bytes).read_bytes(ASN1::BER::Identifier)
+    id.extended.size.should eq(max)
+  end
+
+  it "rejects one more than the maximum number of extended bytes" do
+    max = ASN1::BER::Identifier::MAX_EXTENDED_BYTES
+    bytes = Bytes[0x5F] + Bytes.new(max, 0x81_u8) + Bytes[0x00] # max + 1 parts
+    io = IO::Memory.new(bytes)
+    expect_raises(ASN1::BER::InvalidTag) { io.read_bytes(ASN1::BER::Identifier) }
+  end
+
+  it "round-trips an extended identifier" do
+    original = Bytes[0x5F, 0x81, 0x00]
+    id = IO::Memory.new(original).read_bytes(ASN1::BER::Identifier)
+
+    io = IO::Memory.new
+    id.write(io)
+    io.to_slice.should eq(original)
+  end
+
+  it "reads a plain (non-extended) identifier unchanged" do
+    id = IO::Memory.new(Bytes[0x02]).read_bytes(ASN1::BER::Identifier)
+    id.tag_class.should eq(ASN1::BER::TagClass::Universal)
+    id.tag_number.should eq(2)
+    id.extended.should be_empty
+  end
+end

--- a/src/bindata/asn1/identifier.cr
+++ b/src/bindata/asn1/identifier.cr
@@ -18,6 +18,11 @@ class ASN1::BER < BinData
   class Identifier < BinData
     endian big
 
+    # Cap on high-tag-number continuation bytes, to bound `read` against a stream
+    # of `more`-flagged bytes (otherwise the array grows without limit). 16
+    # base-128 bytes encode a tag number well beyond any real-world use.
+    MAX_EXTENDED_BYTES = 16
+
     bit_field do
       bits 2, tag_class : TagClass = TagClass::Universal
       bool constructed, default: false
@@ -35,6 +40,9 @@ class ASN1::BER < BinData
       if extended?
         @extended = [] of ExtendedIdentifier
         loop do
+          if @extended.size >= MAX_EXTENDED_BYTES
+            raise InvalidTag.new("extended identifier exceeds #{MAX_EXTENDED_BYTES} bytes")
+          end
           extended_id = io.read_bytes(ExtendedIdentifier)
           @extended << extended_id
           break unless extended_id.more


### PR DESCRIPTION
## What

Bounds `ASN1::BER::Identifier` high-tag-number parsing so a hostile stream can't
grow the extended-identifier array without limit. Follow-up to the content-length
DoS cap (#22, audit tier 0.5), closing the residual vector flagged there.

## Why

`Identifier#read` looped appending `ExtendedIdentifier`s while the `more`
continuation bit was set, with no limit:

```crystal
loop do
  extended_id = io.read_bytes(ExtendedIdentifier)
  @extended << extended_id
  break unless extended_id.more
end
```

A stream of `more`-flagged bytes (`0xFF …`) grows `@extended` unbounded (on a
socket, until memory dies). Unlike the length-based vector there's no
amplification, but it's the same exhaustion class and `Identifier` has no access
to the `BER` content-length cap, so it needs its own bound.

## How

A fixed `MAX_EXTENDED_BYTES = 16` (16 base-128 septets encode a tag number far
beyond any real use) caps the loop; exceeding it raises the existing typed
`ASN1::BER::InvalidTag`. Read-path only — `write` serialises a finite,
caller-supplied array and is unchanged.

## Tests

New `spec/bindata_asn1_identifier_spec.cr`: rejects an over-long extended
identifier, parses a valid multi-byte one, round-trips it, leaves a plain
(non-extended) identifier unchanged, and pins the boundary — exactly
`MAX_EXTENDED_BYTES` parses, one more raises. Full suite green (75 examples) in
both default and `-Dpreview_mt` modes; `crystal tool format --check` clean; no
new `ameba` findings on `identifier.cr`.
