### PR TITLE
fix(asn1): correct BER length short/long-form boundary and reject Int32 overflow

### DIFF
--- a/spec/bindata_asn1_length_spec.cr
+++ b/spec/bindata_asn1_length_spec.cr
@@ -1,0 +1,38 @@
+require "./helper"
+
+# Audit Tier 3 — ASN.1 BER length encoding/decoding correctness.
+#  * a length of 127 fits in short form (0x7f) but was encoded in long form;
+#  * a long-form length that overflows Int32 became silently negative.
+
+describe ASN1::BER::Length do
+  it "encodes length boundaries in minimal form" do
+    {
+             126 => Bytes[0x7e],
+             127 => Bytes[0x7f],                         # short form, not 0x81 0x7f
+             128 => Bytes[0x81, 0x80],                   # first value needing long form
+             256 => Bytes[0x82, 0x01, 0x00],             # two long bytes
+           65536 => Bytes[0x83, 0x01, 0x00, 0x00],       # three long bytes
+      0x7FFFFFFF => Bytes[0x84, 0x7F, 0xFF, 0xFF, 0xFF], # max representable
+    }.each do |len, goal|
+      l = ASN1::BER::Length.new
+      l.length = len
+
+      io = IO::Memory.new
+      l.write(io)
+      io.to_slice.should eq(goal)
+
+      io.rewind
+      io.read_bytes(ASN1::BER::Length).length.should eq(len)
+    end
+  end
+
+  it "reads the maximum representable long-form length" do
+    io = IO::Memory.new(Bytes[0x84, 0x7F, 0xFF, 0xFF, 0xFF])
+    io.read_bytes(ASN1::BER::Length).length.should eq(0x7FFFFFFF)
+  end
+
+  it "rejects a long-form length that exceeds Int32" do
+    io = IO::Memory.new(Bytes[0x84, 0x80, 0x00, 0x00, 0x00])
+    expect_raises(ASN1::BER::InvalidLength) { io.read_bytes(ASN1::BER::Length) }
+  end
+end

--- a/src/bindata/asn1/length.cr
+++ b/src/bindata/asn1/length.cr
@@ -1,4 +1,6 @@
 class ASN1::BER < BinData
+  class InvalidLength < Exception; end
+
   class Length < BinData
     endian big
 
@@ -35,6 +37,9 @@ class ASN1::BER < BinData
         long_bytes.reverse.each_with_index do |byte, index|
           @length = @length | (byte.to_i32 << (index * 8))
         end
+        # A 4-byte length with the high bit set overflows the Int32 we store it
+        # in, surfacing as a negative value; reject it rather than misread it.
+        raise InvalidLength.new("ASN.1 length exceeds Int32 maximum") if @length < 0
       else
         @length = length_indicator.to_i32
       end
@@ -42,7 +47,8 @@ class ASN1::BER < BinData
     end
 
     def write(io : IO)
-      self.long = true if @length >= 127
+      # Lengths 0..127 fit in short form; only 128+ need long form.
+      self.long = true if @length > 127
 
       if long
         @long_bytes = [] of UInt8


### PR DESCRIPTION
## What

Two ASN.1 BER length encoding/decoding correctness fixes in
`src/bindata/asn1/length.cr`. Audit tier **3** (#18).

## Why / How

**1. Short/long-form off-by-one.** `write` used
`self.long = true if @length >= 127`, so a length of exactly **127** — which
fits the short form (single octet `0x7f`) — was encoded in long form
(`0x81 0x7f`). Lengths `0..127` fit short form; the boundary is `> 127`.

```crystal
self.long = true if @length > 127
```

The conditional form is kept deliberately (not `self.long = @length > 127`) so it
never resets `long` to `false` — that would break the indefinite form, where
`@length == 0` but `long` must stay `true`.

**2. Length overflow read as a negative Int32.** `read` accumulates a long-form
length into the `Int32` `@length` (`@length |= byte << (index*8)`). A 4-byte
length with the high bit set (e.g. `0x80000000`) overflowed to a silently
**negative** value. It now raises a typed `ASN1::BER::InvalidLength` (consistent
with `InvalidTag` / `InvalidObjectId`) when `@length < 0` after accumulation —
before any payload allocation. `0x7FFFFFFF` (max representable) still reads fine.

## Tests

New `spec/bindata_asn1_length_spec.cr`: write+read round-trips across the
boundaries `126 / 127 / 128`, multi-byte minimal-form encodings `256` (`82 01 00`)
and `65536` (`83 01 00 00`), the max representable `0x7FFFFFFF`
(`84 7F FF FF FF`), and rejection of an `Int32`-overflowing length
(`84 80 00 00 00` → `InvalidLength`). Full suite green (74 examples) in both
default and `-Dpreview_mt` modes; `crystal tool format --check` clean; no new
`ameba` findings on `length.cr`.
