### PR TITLE
chore: adopt a mise-based CI workflow (ameba, multi-threaded specs, macOS)

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,28 @@
+# Ameba configuration for bindata.
+#
+# The rules disabled here are either false positives produced by the BinData
+# macro DSL or intentional, documented naming choices — not real issues.
+
+Lint/UselessAssign:
+  # The `field` / `bits` / `bool` / `group` DSL macros expand to declarations
+  # that ameba reads as useless local assignments (`field x : T`, `bits 8, :y`).
+  # Pervasive false positive across every file that uses the DSL.
+  Enabled: false
+
+Naming/AccessorMethodName:
+  # The ASN.1 BER `get_*` / `set_*` accessors deliberately mirror the wire-format
+  # vocabulary (get_object_id, set_integer, ...); they are not Crystal getters.
+  Enabled: false
+
+Naming/BlockParameterName:
+  # Short index/loop block parameters (e.g. `f`) are idiomatic in the specs.
+  Enabled: false
+
+Documentation/DocumentationAdmonition:
+  # TODO / NOTE comments are allowed as in-code project notes.
+  Enabled: false
+
+Lint/SpecFilename:
+  Excluded:
+    # Shared spec helper required by the suite, not a spec file itself.
+    - spec/helper.cr

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,36 +1,143 @@
+---
 name: CI
+
+permissions: {}
+
 on:
   push:
+    branches:
+      - '**'
+    paths-ignore:
+      - "**.md"
   pull_request:
-  workflow_dispatch:
+    branches:
+      - '**'
+    paths-ignore:
+      - "**.md"
   schedule:
     - cron: "0 6 * * 1"
+  workflow_dispatch:
+
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        crystal:
-          - latest
-          - nightly
-    runs-on: ${{ matrix.os }}
-    container: crystallang/crystal:${{ matrix.crystal }}
+  format:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Add encodings
-      run: |
-        apt-get update
-        apt-get install -y locales
-        sed -i 's/^# \(.*\)$/\1/' /etc/locale.gen
-        locale-gen
-    - name: Install dependencies
-      run: shards install --ignore-crystal-version --skip-postinstall --skip-executables
-    - name: Format
-      run: crystal tool format --check
-    - name: Run tests
-      run: crystal spec -v --error-trace
-    - name: Run tests (multi-threaded)
-      run: crystal spec -v --error-trace -Dpreview_mt
-      env:
-        CRYSTAL_WORKERS: "4"
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+
+      - name: Check formatting
+        run: mise dev:format-check
+
+  ameba:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+
+      - name: Install dependencies
+        run: mise dev:deps
+
+      - name: Run static code analysis
+        run: mise dev:ameba
+
+  test_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+
+      - name: Install dependencies
+        run: mise dev:deps
+
+      - name: Run tests
+        run: mise dev:spec
+
+      - name: Run tests (multi-threaded)
+        run: mise dev:spec-mt
+
+  # Best-effort early warning against the Crystal nightly compiler. mise has no
+  # nightly build, so this job uses the nightly container directly and is allowed
+  # to fail.
+  test_nightly_linux:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    container: crystallang/crystal:nightly
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: shards install --skip-postinstall --skip-executables
+
+      - name: Run tests
+        run: crystal spec --error-trace
+
+      - name: Run tests (multi-threaded)
+        run: crystal spec --error-trace -Dpreview_mt
+        env:
+          CRYSTAL_WORKERS: "4"
+
+  test_macos_arm64:
+    runs-on: macos-26
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+
+      # TODO: remove me when https://github.com/crystal-lang/crystal/issues/16746 is fixed
+      - name: Fix Crystal shards
+        run: mise dev:fix-shards-command
+
+      - name: Install dependencies
+        run: mise dev:deps
+
+      - name: Run tests
+        run: mise dev:spec
+
+      - name: Run tests (multi-threaded)
+        run: mise dev:spec-mt
+
+  test_macos_amd64:
+    runs-on: macos-26-intel
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+
+      # TODO: remove me when https://github.com/crystal-lang/crystal/issues/16746 is fixed
+      - name: Fix Crystal shards
+        run: mise dev:fix-shards-command
+
+      - name: Install dependencies
+        run: mise dev:deps
+
+      - name: Run tests
+        run: mise dev:spec
+
+      - name: Run tests (multi-threaded)
+        run: mise dev:spec-mt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: crystal
-install:
-  - shards install
-script:
-  - crystal spec

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,40 @@
+[tools]
+crystal = "1.20.2"
+
+[vars]
+# Add --verbose only in an interactive terminal (TTY check)
+SPEC_OPTS = "{% if exec(command='(tty -s && echo true) || echo false') == 'true' %}--verbose{% endif %}"
+
+[tasks."dev:deps"]
+description = "Install dependencies (also builds bin/ameba)"
+run = "shards install"
+
+[tasks."dev:format"]
+description = "Format the source"
+run = "crystal tool format src/ spec/"
+
+[tasks."dev:format-check"]
+description = "Check formatting"
+run = "crystal tool format --check"
+
+[tasks."dev:ameba"]
+description = "Run static code analysis"
+run = "bin/ameba"
+
+[tasks."dev:spec"]
+description = "Run the spec suite"
+run = "crystal spec --error-trace {{vars.SPEC_OPTS}}"
+
+[tasks."dev:spec-mt"]
+description = "Run the spec suite multi-threaded (fiber-safety gate)"
+run = "crystal spec --error-trace -Dpreview_mt {{vars.SPEC_OPTS}}"
+env = { CRYSTAL_WORKERS = "4" }
+
+[tasks."dev:check"]
+description = "Format-check, lint and test in one shot"
+run = "mise dev:format-check && mise dev:ameba && mise dev:spec && mise dev:spec-mt"
+
+# TODO: remove me when https://github.com/crystal-lang/crystal/issues/16746 is fixed
+[tasks."dev:fix-shards-command"]
+description = "Fix missing shards command on macOS"
+run = "cp $HOME/.local/share/mise/installs/crystal/{{tools.crystal.version}}/embedded/bin/shards $HOME/.local/share/mise/installs/crystal/{{tools.crystal.version}}/bin/"

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -83,7 +83,9 @@ module ASN1
         # init to 1 as we need two 0 bytes to indicate end of stream
         previous_byte = 1_u8
         loop do
-          current_byte = io.read_byte.not_nil!
+          # NOTE: truncated input surfaces as a NilAssertionError here; a typed
+          # error is tracked separately (audit tier 1, error model).
+          current_byte = io.read_byte.not_nil! # ameba:disable Lint/NotNil
           break if previous_byte == 0_u8 && current_byte == 0_u8
           temp.write_byte previous_byte
           ensure_content_length(temp.pos)


### PR DESCRIPTION
## What

Modernizes CI by adopting a [`mise`](https://mise.jdx.dev)-based workflow, modelled
on `spider-gazelle/mcp.cr`. Audit tier 5 housekeeping.

## Changes

- **`mise.toml`** — pins the Crystal toolchain (1.20.2) and defines the dev tasks:
  `dev:deps`, `dev:format` / `dev:format-check`, `dev:ameba`, `dev:spec`,
  `dev:spec-mt` (the `-Dpreview_mt` fiber-safety gate), and `dev:check`. These give
  the same one-liners locally and in CI.
- **`CI.yml`** — rewritten into parallel `mise`-driven jobs: `format`, `ameba`,
  `test_linux` (single- and multi-threaded specs), `test_macos_arm64`,
  `test_macos_amd64`, plus a best-effort `test_nightly_linux` (the Crystal nightly
  container, `continue-on-error`, since `mise` has no nightly build). Uses
  `actions/checkout@v6` with `persist-credentials: false`, `permissions: {}`, and
  `paths-ignore: "**.md"`.
- **Remove the obsolete locale step** — the old job generated *all* locales for the
  `GB2312` string-encoding spec. That isn't needed on the current glibc images
  (iconv ships the charset); verified the full suite passes without it on both
  `latest` and `nightly`.
- **Drop the dead `.travis.yml`** (the project is on GitHub Actions).
- **Add `.ameba.yml`** disabling rules that are false positives from the BinData
  macro DSL (`Lint/UselessAssign`) or intentional (`get_*`/`set_*` accessor names),
  each with a justifying comment, so the new `ameba` job is meaningful. One real
  `not_nil!` is annotated inline, with the typed-error fix tracked for the
  error-model tier.

Validated locally with `mise`: `dev:deps` → `dev:ameba` (0 findings) → `dev:spec`
(71) → `dev:spec-mt` (71); `dev:format-check` clean.

## Notes for the maintainer

- Crystal is **pinned to 1.20.2** (vs the old floating `latest`); bump the
  `mise.toml` to move it. Nightly is still exercised, best-effort.
- macOS runners mirror mcp.cr (`macos-26`, `macos-26-intel`) including the
  `dev:fix-shards-command` workaround for crystal-lang/crystal#16746.
- `Lint/UselessAssign` is disabled globally (the DSL is used in nearly every
  file); happy to scope it down if you prefer.
