### PR TITLE
docs: document the public BinData and ASN1::BER API

### DIFF
--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -1,6 +1,25 @@
 require "./bindata/exceptions"
 require "./bindata/bitfield"
 
+# Declarative reader/writer for structured binary data.
+#
+# Subclass `BinData`, declare the wire layout with the `field` / `bit_field` /
+# `group` / `endian` DSL, and the class learns how to (de)serialize itself from
+# any `IO`:
+#
+# ```
+# class Packet < BinData
+#   endian big
+#
+#   field size : UInt16, value: -> { payload.size }
+#   field payload : Bytes, length: -> { size }
+# end
+#
+# packet = io.read_bytes(Packet) # decode
+# io.write_bytes(packet)         # encode
+# ```
+#
+# See `#field` for the supported field types and their options.
 abstract class BinData
   INDEX        = [-1]
   BIT_PARTS    = [] of Nil
@@ -67,17 +86,32 @@ abstract class BinData
     IO::ByteFormat::SystemEndian
   end
 
+  # Decodes an instance from a byte slice.
+  #
+  # The declared `endian` of the type is used; the *format* argument is accepted
+  # for `IO` interoperability but does not override it.
   def self.from_slice(bytes : Slice, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
     io = IO::Memory.new(bytes)
     from_io(io, format)
   end
 
+  # Encodes this instance to a freshly allocated byte slice.
   def to_slice
     io = IO::Memory.new
     io.write_bytes self
     io.to_slice
   end
 
+  # Sets the default byte order for every field of the type.
+  #
+  # Accepts `little`, `big`, `network` (an alias for big-endian) or `system`.
+  # Individual fields may still override it with the `field ..., endian:` option.
+  #
+  # ```
+  # class Header < BinData
+  #   endian big
+  # end
+  # ```
   macro endian(format)
     def __format__ : IO::ByteFormat
       {% format = format.id.stringify %}
@@ -94,6 +128,9 @@ abstract class BinData
     end
   end
 
+  # Reads the fields of this instance from *io*, in declaration order, and
+  # returns *io*. Raises `BinData::ParseError` (or `BinData::VerificationException`)
+  # on malformed input.
   def read(io : IO) : IO
     __perform_read__(io)
   end
@@ -102,6 +139,8 @@ abstract class BinData
     io
   end
 
+  # Writes the fields of this instance to *io* in declaration order. Raises
+  # `BinData::WriteError` (or `BinData::VerificationException`) on failure.
   def write(io : IO)
     __perform_write__(io)
     0_i64
@@ -111,10 +150,14 @@ abstract class BinData
     io
   end
 
+  # Writes this instance to *io* (`IO#write_bytes` entry point). The type's
+  # declared `endian` is used; *format* is accepted but not applied.
   def to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
     write(io)
   end
 
+  # Reads an instance from *io* (`IO#read_bytes` entry point). The type's
+  # declared `endian` is used; *format* is accepted but not applied.
   def self.from_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
     data = self.new
     data.read(io)
@@ -409,6 +452,17 @@ abstract class BinData
     end
   end
 
+  # Declares a *size*-bit field inside a `bit_field` block (1 to 128 bits).
+  #
+  # The accessor is typed as the smallest unsigned integer that holds *size*
+  # bits. A `name : EnumType` declaration exposes the value as that enum.
+  #
+  # ```
+  # bit_field do
+  #   bits 5, reserved
+  #   bits 2, input : Inputs = Inputs::HDMI
+  # end
+  # ```
   macro bits(size, name, value = nil, default = nil)
     {% resolved_type = nil %}
 
@@ -471,6 +525,7 @@ abstract class BinData
     bits {{size}}, {{name}}
   end
 
+  # Declares a single-bit boolean field inside a `bit_field` block.
   macro bool(name, default = false)
     {% if name.is_a?(Assign) %}
       {% if name.value %}
@@ -491,6 +546,11 @@ abstract class BinData
     end
   end
 
+  # Groups `bits` / `bool` fields that are not byte-aligned. The total number of
+  # bits declared in the block must be divisible by 8. Use only when fields share
+  # a byte; byte-aligned values should be plain `field`s.
+  #
+  # Accepts the same *onlyif* / *verify* callbacks as `field`.
   macro bit_field(onlyif = nil, verify = nil, &block)
     {% INDEX[0] = INDEX[0] + 1 %}
     {% BIT_PARTS << {} of Nil => Nil %}
@@ -502,7 +562,17 @@ abstract class BinData
     {% PARTS << {type: "bitfield", name: INDEX[0], cls: KLASS_NAME[0], onlyif: onlyif, verify: verify} %}
   end
 
-  # }# Encapsulates a bunch of fields by creating a nested BinData class
+  # Declares a nested, isolated group of fields as its own `BinData` class.
+  #
+  # The group exposes a `parent` accessor for callbacks that need data from the
+  # enclosing type, and accepts the same *onlyif* / *verify* / *value* options as
+  # `field`. Useful for related or optional sub-structures.
+  #
+  # ```
+  # group :header, onlyif: -> { start == 0xFF } do
+  #   field version : UInt8
+  # end
+  # ```
   macro group(name, onlyif = nil, verify = nil, value = nil, &block)
     class {{name.id.stringify.camelcase.id}} < BinData
       endian({{ENDIAN[0]}})
@@ -521,6 +591,9 @@ abstract class BinData
     {% PARTS << {type: "group", name: name.id, cls: name.id.stringify.camelcase.id, onlyif: onlyif, verify: verify, value: value} %}
   end
 
+  # Reads every remaining byte of the `IO` into a `Bytes` field. Must be the last
+  # field, and requires a sized `IO` (e.g. `IO::Memory`). Accepts *onlyif* /
+  # *verify* callbacks.
   macro remaining_bytes(name, onlyif = nil, verify = nil, default = nil)
     {% REMAINING << {type: "bytes", name: name.id, onlyif: onlyif, verify: verify} %}
     property {{name.id}} : Bytes = {% if default %} {{default}}.to_slice {% else %} Bytes.new(0) {% end %}
@@ -531,6 +604,29 @@ abstract class BinData
     {% PARTS << {type: "enum", name: name, cls: cls, onlyif: onlyif, verify: verify, value: value, encoding: encoding, enum_type: enum_type} %}
   end
 
+  # Declares a binary field from a type declaration (`name : Type [= default]`).
+  #
+  # The supported field types are:
+  # * integers (`UInt8`..`UInt128`, `Int8`..`Int128`) and floats (`Float32`/`Float64`)
+  # * `String` — null-terminated, or fixed-size with `length:` (and optional `encoding:`)
+  # * `Bytes` — requires a `length:` callback
+  # * `Enum` types — require a default value
+  # * `Array`/`Set` — require `length:` (fixed) or `read_next:` (variable)
+  # * any other `BinData` / IO-serializable type (custom field)
+  #
+  # Options (all accept a `Proc`, evaluated against the instance):
+  # * *onlyif* — read/write the field only when the callback returns true
+  # * *verify* — raise `BinData::VerificationException` unless the callback returns true
+  # * *value* — compute the field's value just before writing (e.g. a length/checksum)
+  # * *length* — element/byte count for sized `Bytes`/`String`/`Array`/`Set`
+  # * *read_next* — keep reading array elements while the callback returns true
+  # * *encoding* — string encoding for fixed-size `String` fields
+  # * *endian* — override the type's byte order for this field (numeric fields)
+  #
+  # ```
+  # field size : UInt16, value: -> { text.bytesize }
+  # field text : String, length: -> { size }
+  # ```
   macro field(type_declaration, onlyif = nil, verify = nil, value = nil, length = nil, read_next = nil, encoding = nil, endian = nil)
     {% if !type_declaration.is_a?(TypeDeclaration) %}
       {% raise "#{type_declaration} must be a TypeDeclaration" %}
@@ -572,10 +668,14 @@ abstract class BinData
     {% end %}
   end
 
+  # Registers a callback run on the instance just before it is written, e.g. to
+  # derive raw fields from a friendlier representation.
   macro before_serialize(&block)
     {% BEFORE_SERIALIZE << block %}
   end
 
+  # Registers a callback run on the instance just after it is read, e.g. to expose
+  # a friendlier representation of the raw fields.
   macro after_deserialize(&block)
     {% AFTER_DESERIALIZE << block %}
   end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -9,6 +9,25 @@ require "./asn1/length"
 require "./asn1/data_types"
 
 module ASN1
+  # A single ASN.1 Basic Encoding Rules (BER) TLV element: an identifier (tag),
+  # a length and a payload. Used to build and parse SNMP, LDAP, X.509 and similar
+  # protocols.
+  #
+  # ```
+  # require "bindata/asn1"
+  #
+  # ber = ASN1::BER.new
+  # ber.set_integer(42)
+  # io.write_bytes(ber)
+  #
+  # ber = io.read_bytes(ASN1::BER)
+  # ber.get_integer # => 42
+  # ```
+  #
+  # Typed payload accessors live in `data_types.cr` (`get_integer`/`set_integer`,
+  # `get_object_id`/`set_object_id`, `get_string`, `get_boolean`, ...). A
+  # constructed element can be split into / built from sub-elements with
+  # `#children` / `#children=`.
   class BER < BinData
     endian big
 
@@ -55,6 +74,8 @@ module ASN1
       @identifier.tag_number = tag_type.to_i.to_u8
     end
 
+    # The universal tag as a `UniversalTags` enum. Raises unless this is a
+    # universal-class element.
     def tag
       raise "only valid for universal tags" unless tag_class == TagClass::Universal
       UniversalTags.new tag_number.to_i
@@ -72,6 +93,7 @@ module ASN1
       @identifier.extended
     end
 
+    # The decoded payload length in bytes.
     def size
       @length.length
     end
@@ -122,14 +144,16 @@ module ASN1
       0_i64
     end
 
-    # Check if this can be expanded into multiple sub-entries
+    # Whether this is a constructed universal Sequence or Set, i.e. an element
+    # whose payload is itself a list of BER elements (see `#children`).
     def sequence?
       return false unless tag_class == TagClass::Universal
       tag = UniversalTags.new tag_number.to_i
       constructed && {UniversalTags::Sequence, UniversalTags::Set}.includes?(tag)
     end
 
-    # Extracts children from the payload
+    # Parses the payload as a sequence of nested BER elements. The
+    # `max_content_length` cap propagates to each child.
     def children
       parts = [] of BER
       io = IO::Memory.new(@payload)
@@ -143,6 +167,7 @@ module ASN1
       parts
     end
 
+    # Encodes *parts* into the payload and marks this element constructed.
     def children=(parts)
       self.constructed = true
       io = IO::Memory.new

--- a/src/bindata/asn1/data_types.cr
+++ b/src/bindata/asn1/data_types.cr
@@ -1,10 +1,14 @@
 require "big"
 
 class ASN1::BER < BinData
+  # Raised by a typed accessor when the element's tag class/number doesn't match
+  # the type being requested.
   class InvalidTag < Exception; end
 
+  # Raised when an object identifier string or encoding is malformed.
   class InvalidObjectId < Exception; end
 
+  # The ASN.1 universal tag numbers, in tag-number order.
   enum UniversalTags
     EndOfContent
     Boolean
@@ -152,6 +156,7 @@ class ASN1::BER < BinData
     @payload
   end
 
+  # Sets the raw payload bytes and the given tag.
   def set_bytes(data, tag = UniversalTags::OctetString, tag_class = TagClass::Universal)
     self.tag_class = tag_class
     self.tag_number = tag
@@ -178,11 +183,13 @@ class ASN1::BER < BinData
     self
   end
 
+  # Reads the payload as a BOOLEAN.
   def get_boolean
     ensure_universal(UniversalTags::Boolean)
     @payload[0] != 0_u8
   end
 
+  # Sets a BOOLEAN payload.
   def set_boolean(value)
     self.tag_class = TagClass::Universal
     self.tag_number = UniversalTags::Boolean
@@ -191,6 +198,7 @@ class ASN1::BER < BinData
     self
   end
 
+  # Reads the payload as a two's-complement signed INTEGER (or ENUMERATED).
   def get_integer(check_tags = {UniversalTags::Integer, UniversalTags::Enumerated}, check_class = TagClass::Universal) : Int64
     raise InvalidTag.new("not a universal tag: #{tag_class}") unless tag_class == check_class
     raise InvalidTag.new("object is a #{tag}, expecting one of #{check_tags}") unless check_tags.includes?(tag)
@@ -219,6 +227,7 @@ class ASN1::BER < BinData
     start
   end
 
+  # Returns the INTEGER payload as raw bytes, with a leading zero/sign pad removed.
   def get_integer_bytes : Bytes
     ensure_universal(UniversalTags::Integer)
     return Bytes.new(0) if @payload.size == 0
@@ -227,6 +236,7 @@ class ASN1::BER < BinData
     @payload
   end
 
+  # Encodes *value* as a minimal two's-complement INTEGER payload.
   # ameba:disable Metrics/CyclomaticComplexity
   def set_integer(value, tag = UniversalTags::Integer, tag_class = TagClass::Universal)
     self.tag_class = tag_class
@@ -283,6 +293,7 @@ class ASN1::BER < BinData
     self
   end
 
+  # Reads the payload as a BIT STRING (only the zero-unused-bits form is supported).
   def get_bitstring
     ensure_universal(UniversalTags::BitString)
     if @payload[0] == 0

--- a/src/bindata/asn1/identifier.cr
+++ b/src/bindata/asn1/identifier.cr
@@ -1,4 +1,5 @@
 class ASN1::BER < BinData
+  # The class of an ASN.1 tag.
   enum TagClass
     Universal
     Application
@@ -6,6 +7,8 @@ class ASN1::BER < BinData
     Private
   end
 
+  # One continuation byte of a high-tag-number (extended) identifier: a 7-bit
+  # chunk of the tag number plus a `more` bit.
   class ExtendedIdentifier < BinData
     endian big
 
@@ -15,6 +18,8 @@ class ASN1::BER < BinData
     end
   end
 
+  # The leading identifier octet of a BER element (tag class, constructed flag and
+  # tag number), plus any high-tag-number continuation bytes.
   class Identifier < BinData
     endian big
 

--- a/src/bindata/asn1/length.cr
+++ b/src/bindata/asn1/length.cr
@@ -1,4 +1,6 @@
 class ASN1::BER < BinData
+  # The length octets of a BER element: short form, long form, or the indefinite
+  # marker. The decoded byte count is exposed as `#length`.
   class Length < BinData
     endian big
 

--- a/src/bindata/exceptions.cr
+++ b/src/bindata/exceptions.cr
@@ -1,4 +1,6 @@
 abstract class BinData
+  # Base class for every error raised while (de)serializing. Carries the failing
+  # type, field and field type when known, so they can be inspected by a `rescue`.
   class CustomException < Exception
     getter klass : String?
     getter field : String?
@@ -13,26 +15,31 @@ abstract class BinData
     end
   end
 
+  # Raised when a field's `verify:` callback returns false.
   class VerificationException < CustomException; end
 
+  # Raised when a `verify:` callback fails while writing a field.
   class WritingVerificationException < VerificationException
     def initialize(@klass, @field, @field_type)
       super("Failed to verify writing #{field_type} at #{klass}.#{field}")
     end
   end
 
+  # Raised when a `verify:` callback fails while reading a field.
   class ReadingVerificationException < VerificationException
     def initialize(@klass, @field, @field_type)
       super("Failed to verify reading #{field_type} at #{klass}.#{field}")
     end
   end
 
+  # Wraps any error raised while reading a field, tagged with its location.
   class ParseError < CustomException
     def initialize(@klass, @field, ex : Exception)
       super("Failed to parse #{klass}.#{field}", ex)
     end
   end
 
+  # Wraps any error raised while writing a field, tagged with its location.
   class WriteError < CustomException
     def initialize(@klass, @field, ex : Exception)
       super("Failed to write #{klass}.#{field}", ex)


### PR DESCRIPTION
## What

Documents the public API so `crystal docs` produces a usable reference. **Doc
comments only — no behavior change.** Part of the audit tier 5 housekeeping.

## Covered

- **`BinData`** — class overview with a runnable example, and the `field` macro
  fully documented (every field type and every option: `onlyif` / `verify` /
  `value` / `length` / `read_next` / `encoding` / `endian`).
- **DSL macros** — `endian`, `bits`, `bool`, `bit_field`, `group`,
  `remaining_bytes`, `before_serialize`, `after_deserialize`.
- **(De)serialization entry points** — `read` / `write` (incl. which exceptions
  they raise) and `to_slice` / `from_slice` / `to_io` / `from_io` (incl. the
  note that the `IO::ByteFormat` argument is accepted but the declared `endian`
  wins).
- **Exception hierarchy** — `CustomException` and its subclasses.
- **`ASN1::BER`** — element overview, `tag` / `size` / `sequence?` / `children` /
  `children=`, the typed payload accessors in `data_types.cr`, and the
  `InvalidTag` / `InvalidObjectId` / `TagClass` / `Identifier` / `Length` types.

## Verification

`crystal docs` generates without error; `crystal spec` unchanged (71 examples);
`crystal tool format --check` clean; no new `ameba` findings. Every documented
claim was cross-checked against the implementation.
