### PR TITLE
refactor(asn1): consolidate errors under ASN1::Error + typed empty-payload error

### DIFF
--- a/spec/bindata_asn1_dos_spec.cr
+++ b/spec/bindata_asn1_dos_spec.cr
@@ -24,7 +24,7 @@ describe "ASN1::BER max_content_length" do
   it "rejects a definite length larger than the cap before allocating" do
     # OctetString, long-form length 0x7FFFFFFF (~2 GiB), no payload follows.
     header = Bytes[0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF]
-    expect_raises(ASN1::BER::ContentTooLarge) { read_capped(header, 1024) }
+    expect_raises(ASN1::ContentTooLarge) { read_capped(header, 1024) }
   end
 
   it "bounds an indefinite-length value with no terminator" do
@@ -32,14 +32,14 @@ describe "ASN1::BER max_content_length" do
     data = Bytes.new(64, 0x01_u8)
     data[0] = 0x24_u8 # constructed
     data[1] = 0x80_u8 # indefinite length
-    expect_raises(ASN1::BER::ContentTooLarge) { read_capped(data, 16) }
+    expect_raises(ASN1::ContentTooLarge) { read_capped(data, 16) }
   end
 
   it "propagates the cap into children (no amplification)" do
     # 8-byte SEQUENCE whose 6-byte payload nests a child announcing ~2 GiB.
     frame = Bytes[0x30, 0x06, 0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF]
     root = read_capped(frame, 1024) # the outer frame is small, so this succeeds
-    expect_raises(ASN1::BER::ContentTooLarge) { root.children }
+    expect_raises(ASN1::ContentTooLarge) { root.children }
   end
 
   it "reads a normal frame that fits within the cap" do
@@ -60,6 +60,6 @@ describe "ASN1::BER max_content_length" do
     # SEQUENCE { SEQUENCE { OCTET STRING announcing ~2 GiB } }
     frame = Bytes[0x30, 0x08, 0x30, 0x06, 0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF]
     child = read_capped(frame, 1024).children.first
-    expect_raises(ASN1::BER::ContentTooLarge) { child.children }
+    expect_raises(ASN1::ContentTooLarge) { child.children }
   end
 end

--- a/spec/bindata_asn1_identifier_spec.cr
+++ b/spec/bindata_asn1_identifier_spec.cr
@@ -12,7 +12,7 @@ describe ASN1::BER::Identifier do
   it "rejects an over-long extended identifier" do
     bytes = Bytes[0x5F] + Bytes.new(20, 0xFF_u8) # 20 continuation bytes, never terminates
     io = IO::Memory.new(bytes)
-    expect_raises(ASN1::BER::InvalidTag) { io.read_bytes(ASN1::BER::Identifier) }
+    expect_raises(ASN1::InvalidTag) { io.read_bytes(ASN1::BER::Identifier) }
   end
 
   it "reads a valid multi-byte extended identifier" do
@@ -33,7 +33,7 @@ describe ASN1::BER::Identifier do
     max = ASN1::BER::Identifier::MAX_EXTENDED_BYTES
     bytes = Bytes[0x5F] + Bytes.new(max, 0x81_u8) + Bytes[0x00] # max + 1 parts
     io = IO::Memory.new(bytes)
-    expect_raises(ASN1::BER::InvalidTag) { io.read_bytes(ASN1::BER::Identifier) }
+    expect_raises(ASN1::InvalidTag) { io.read_bytes(ASN1::BER::Identifier) }
   end
 
   it "round-trips an extended identifier" do

--- a/spec/bindata_asn1_length_spec.cr
+++ b/spec/bindata_asn1_length_spec.cr
@@ -33,6 +33,6 @@ describe ASN1::BER::Length do
 
   it "rejects a long-form length that exceeds Int32" do
     io = IO::Memory.new(Bytes[0x84, 0x80, 0x00, 0x00, 0x00])
-    expect_raises(ASN1::BER::InvalidLength) { io.read_bytes(ASN1::BER::Length) }
+    expect_raises(ASN1::InvalidLength) { io.read_bytes(ASN1::BER::Length) }
   end
 end

--- a/spec/bindata_asn1_payload_spec.cr
+++ b/spec/bindata_asn1_payload_spec.cr
@@ -1,0 +1,44 @@
+require "./helper"
+
+# Audit Tier 1 — typed errors on malformed input. `get_boolean` / `get_bitstring`
+# indexed `@payload[0]` without a bounds check, raising `IndexError` on an empty
+# payload instead of a meaningful, typed ASN.1 error.
+
+describe "ASN1::BER empty payloads" do
+  it "raises a typed error on an empty BOOLEAN payload" do
+    ber = ASN1::BER.new
+    ber.tag_number = ASN1::BER::UniversalTags::Boolean
+    ber.payload = Bytes.new(0)
+    expect_raises(ASN1::InvalidPayload) { ber.get_boolean }
+  end
+
+  it "raises a typed error on an empty BIT STRING payload" do
+    ber = ASN1::BER.new
+    ber.tag_number = ASN1::BER::UniversalTags::BitString
+    ber.payload = Bytes.new(0)
+    expect_raises(ASN1::InvalidPayload) { ber.get_bitstring }
+  end
+
+  it "prefers InvalidTag over InvalidPayload for a wrong-tag empty payload" do
+    ber = ASN1::BER.new
+    ber.tag_number = ASN1::BER::UniversalTags::Integer # not Boolean
+    ber.payload = Bytes.new(0)
+    expect_raises(ASN1::InvalidTag) { ber.get_boolean }
+  end
+
+  it "is catchable via the ASN1::Error parent" do
+    ber = ASN1::BER.new
+    ber.tag_number = ASN1::BER::UniversalTags::Boolean
+    ber.payload = Bytes.new(0)
+    expect_raises(ASN1::Error) { ber.get_boolean }
+  end
+
+  it "still reads valid BOOLEAN and BIT STRING payloads" do
+    ber = ASN1::BER.new
+    ber.set_boolean(true)
+    ber.get_boolean.should eq(true)
+
+    bs = IO::Memory.new(Bytes[0x03, 0x02, 0x0, 0x1]).read_bytes(ASN1::BER)
+    bs.get_bitstring.should eq(Bytes[0x1])
+  end
+end

--- a/spec/bindata_asn1_spec.cr
+++ b/spec/bindata_asn1_spec.cr
@@ -257,16 +257,16 @@ describe ASN1 do
   end
 
   it "rejects malformed object identifiers" do
-    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("3.1.1") } # first arc > 2
-    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("0.40") }  # first < 2, second >= 40
-    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("1.40") }  # first < 2, second >= 40
-    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("1.-1") }  # negative arc
-    expect_raises(ASN1::BER::InvalidObjectId) { ASN1::BER.new.set_object_id("1.x") }   # non-numeric arc
+    expect_raises(ASN1::InvalidObjectId) { ASN1::BER.new.set_object_id("3.1.1") } # first arc > 2
+    expect_raises(ASN1::InvalidObjectId) { ASN1::BER.new.set_object_id("0.40") }  # first < 2, second >= 40
+    expect_raises(ASN1::InvalidObjectId) { ASN1::BER.new.set_object_id("1.40") }  # first < 2, second >= 40
+    expect_raises(ASN1::InvalidObjectId) { ASN1::BER.new.set_object_id("1.-1") }  # negative arc
+    expect_raises(ASN1::InvalidObjectId) { ASN1::BER.new.set_object_id("1.x") }   # non-numeric arc
   end
 
   it "rejects a payload truncated mid sub-identifier (trailing continuation bit)" do
     # 0x2a decodes fine (42), 0x86 sets the continuation bit but no octet follows.
     io = IO::Memory.new(Bytes[6, 2, 0x2a, 0x86])
-    expect_raises(ASN1::BER::InvalidObjectId) { io.read_bytes(ASN1::BER).get_object_id }
+    expect_raises(ASN1::InvalidObjectId) { io.read_bytes(ASN1::BER).get_object_id }
   end
 end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -4,6 +4,7 @@ module ASN1; end
 
 class BER < BinData; end
 
+require "./asn1/exceptions"
 require "./asn1/identifier"
 require "./asn1/length"
 require "./asn1/data_types"
@@ -30,10 +31,6 @@ module ASN1
   # `#children` / `#children=`.
   class BER < BinData
     endian big
-
-    # Raised when a declared content length exceeds `max_content_length`.
-    class ContentTooLarge < Exception
-    end
 
     # Components of a BER object
     field identifier : Identifier = Identifier.new

--- a/src/bindata/asn1/data_types.cr
+++ b/src/bindata/asn1/data_types.cr
@@ -1,13 +1,6 @@
 require "big"
 
 class ASN1::BER < BinData
-  # Raised by a typed accessor when the element's tag class/number doesn't match
-  # the type being requested.
-  class InvalidTag < Exception; end
-
-  # Raised when an object identifier string or encoding is malformed.
-  class InvalidObjectId < Exception; end
-
   # The ASN.1 universal tag numbers, in tag-number order.
   enum UniversalTags
     EndOfContent
@@ -186,6 +179,7 @@ class ASN1::BER < BinData
   # Reads the payload as a BOOLEAN.
   def get_boolean
     ensure_universal(UniversalTags::Boolean)
+    raise InvalidPayload.new("empty BOOLEAN payload") if @payload.empty?
     @payload[0] != 0_u8
   end
 
@@ -296,6 +290,7 @@ class ASN1::BER < BinData
   # Reads the payload as a BIT STRING (only the zero-unused-bits form is supported).
   def get_bitstring
     ensure_universal(UniversalTags::BitString)
+    raise InvalidPayload.new("empty BIT STRING payload") if @payload.empty?
     if @payload[0] == 0
       @payload[1, @payload.size - 1]
     else

--- a/src/bindata/asn1/exceptions.cr
+++ b/src/bindata/asn1/exceptions.cr
@@ -1,0 +1,21 @@
+module ASN1
+  # Base class for every ASN.1 error, so callers can `rescue ASN1::Error` to catch
+  # any ASN.1 decode/encode failure at once.
+  class Error < Exception; end
+
+  # Raised by a typed accessor when the element's tag class/number doesn't match
+  # the type being requested.
+  class InvalidTag < Error; end
+
+  # Raised when an object identifier string or encoding is malformed.
+  class InvalidObjectId < Error; end
+
+  # Raised when a payload is too short / malformed for the requested type.
+  class InvalidPayload < Error; end
+
+  # Raised when a declared content length exceeds `ASN1::BER#max_content_length`.
+  class ContentTooLarge < Error; end
+
+  # Raised when a BER length is malformed or exceeds the representable range.
+  class InvalidLength < Error; end
+end

--- a/src/bindata/asn1/length.cr
+++ b/src/bindata/asn1/length.cr
@@ -1,6 +1,4 @@
 class ASN1::BER < BinData
-  class InvalidLength < Exception; end
-
   # The length octets of a BER element: short form, long form, or the indefinite
   # marker. The decoded byte count is exposed as `#length`.
   class Length < BinData


### PR DESCRIPTION
## What

Consolidates the ASN.1 error classes under a single parent and raises a typed
error on empty payloads. Addresses the review feedback here plus audit tier 1.

## Changes

- New `src/bindata/asn1/exceptions.cr`: a parent `ASN1::Error < Exception` with
  `InvalidTag`, `InvalidObjectId`, `InvalidPayload`, `ContentTooLarge` and
  `InvalidLength` as subclasses, so `rescue ASN1::Error` catches any ASN.1
  decode/encode failure.
- The scattered definitions (in `data_types.cr`, `asn1.cr`, `length.cr`) are
  removed; the file is required early so every raise site resolves to it.
- `get_boolean` / `get_bitstring` now raise `ASN1::InvalidPayload` instead of
  `IndexError` on an empty payload (after `ensure_universal`, so a wrong tag still
  raises `InvalidTag`).

## API note

The error classes move from the `ASN1::BER::` namespace to `ASN1::`
(`ASN1::BER::InvalidTag` → `ASN1::InvalidTag`, etc.). Specs are updated; the
`ASN1::BER::Identifier` / `Length` types are unchanged.

## Field references

Kept `ASN1::Error < Exception` as in your example; the errors carry their cause in
the message (expected vs actual tag, the offending value/length). If you'd rather
they expose a queryable field/context attribute, say so and I'll add it to
`ASN1::Error`.

## Tests

`spec/bindata_asn1_payload_spec.cr` covers empty BOOLEAN / BIT STRING (→
`InvalidPayload`), wrong-tag precedence (→ `InvalidTag`), the `ASN1::Error`
catch-all, and valid decodes. Full suite green (85 examples) in both default and
`-Dpreview_mt` modes; format clean; ameba clean.
