### PR TITLE
feat(bitfield): support little-endian bit fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Then you can specify the structures fields. There are a few different field type
 3. Bit Fields
    * a group of fields whose values are defined by the number of bits used to represent them
    * the total number of bits in a bit field must be divisible by 8
+   * they follow the class `endian` (`little` byte-swaps the bitfield); override per field with `bit_field endian: :little`/`:big`
 4. Groups
    * an embedded `BinData` class with access to the parent fields
    * useful when a group of fields are related or optional

--- a/spec/bindata_little_endian_bitfield_spec.cr
+++ b/spec/bindata_little_endian_bitfield_spec.cr
@@ -1,0 +1,124 @@
+require "./helper"
+
+class LeBits < BinData
+  endian little
+  bit_field do
+    bits 4, :a
+    bits 12, :b
+  end
+end
+
+class BeBits < BinData
+  endian big
+  bit_field do
+    bits 4, :a
+    bits 12, :b
+  end
+end
+
+class OverrideBits < BinData
+  endian big
+  bit_field endian: :little do
+    bits 4, :a
+    bits 12, :b
+  end
+end
+
+# `endian: :big` override inside a little-endian class
+class ReverseOverrideBits < BinData
+  endian little
+  bit_field endian: :big do
+    bits 4, :a
+    bits 12, :b
+  end
+end
+
+# odd, 3-byte bitfield with fields crossing several byte boundaries
+class WideLeBits < BinData
+  endian little
+  bit_field do
+    bits 4, :a
+    bits 5, :b
+    bits 15, :c
+  end
+end
+
+class WideBeBits < BinData
+  endian big
+  bit_field do
+    bits 4, :a
+    bits 5, :b
+    bits 15, :c
+  end
+end
+
+describe "little-endian bit fields" do
+  it "byte-reverses the bitfield and round-trips" do
+    le = LeBits.new
+    le.a = 0xA_u8
+    le.b = 0x123_u16
+
+    io = IO::Memory.new
+    le.write(io)
+    bytes = io.to_slice
+
+    # same field values, big-endian, for comparison
+    be = BeBits.new
+    be.a = 0xA_u8
+    be.b = 0x123_u16
+    be_bytes = IO::Memory.new.tap { |m| be.write(m) }.to_slice
+
+    bytes.should eq(be_bytes.dup.reverse!) # little-endian wire = byte-reverse of big-endian
+
+    rt = IO::Memory.new(bytes).read_bytes(LeBits)
+    rt.a.should eq(0xA_u8)
+    rt.b.should eq(0x123_u16)
+  end
+
+  it "honors a per-bit_field endian override" do
+    o = OverrideBits.new
+    o.a = 0xA_u8
+    o.b = 0x123_u16
+    io = IO::Memory.new
+    o.write(io)
+
+    rt = IO::Memory.new(io.to_slice).read_bytes(OverrideBits)
+    rt.a.should eq(0xA_u8)
+    rt.b.should eq(0x123_u16)
+
+    # same as a LeBits little-endian bitfield, not the big-endian class default
+    le_bytes = IO::Memory.new.tap { |m| LeBits.new.tap { |x| x.a = 0xA_u8; x.b = 0x123_u16 }.write(m) }.to_slice
+    io.to_slice.should eq(le_bytes)
+  end
+
+  it "honors a big-endian override inside a little-endian class" do
+    o = ReverseOverrideBits.new
+    o.a = 0xA_u8
+    o.b = 0x123_u16
+    bytes = IO::Memory.new.tap { |m| o.write(m) }.to_slice
+
+    # forced big-endian: identical to the BeBits class, not byte-reversed
+    be_bytes = IO::Memory.new.tap { |m| BeBits.new.tap { |x| x.a = 0xA_u8; x.b = 0x123_u16 }.write(m) }.to_slice
+    bytes.should eq(be_bytes)
+
+    rt = IO::Memory.new(bytes).read_bytes(ReverseOverrideBits)
+    rt.a.should eq(0xA_u8)
+    rt.b.should eq(0x123_u16)
+  end
+
+  it "byte-reverses a 3-byte bitfield with fields crossing boundaries" do
+    le = WideLeBits.new
+    le.a = 0xA_u8
+    le.b = 0x15_u8
+    le.c = 0x1234_u16
+    bytes = IO::Memory.new.tap { |m| le.write(m) }.to_slice
+
+    be_bytes = IO::Memory.new.tap { |m| WideBeBits.new.tap { |x| x.a = 0xA_u8; x.b = 0x15_u8; x.c = 0x1234_u16 }.write(m) }.to_slice
+    bytes.should eq(be_bytes.dup.reverse!)
+
+    rt = IO::Memory.new(bytes).read_bytes(WideLeBits)
+    rt.a.should eq(0xA_u8)
+    rt.b.should eq(0x15_u8)
+    rt.c.should eq(0x1234_u16)
+  end
+end

--- a/spec/bitfield_spec.cr
+++ b/spec/bitfield_spec.cr
@@ -16,7 +16,7 @@ describe BinData::BitField do
     bf.bits 23, :three
     bf.apply
 
-    values = bf.read(io, IO::ByteFormat::LittleEndian)
+    values = bf.read(io, IO::ByteFormat::BigEndian)
     values["seven"].should eq(0b1110111)
     values["two"].should eq(0b01)
     values["three"].should eq(0)

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -550,8 +550,14 @@ abstract class BinData
   # bits declared in the block must be divisible by 8. Use only when fields share
   # a byte; byte-aligned values should be plain `field`s.
   #
+  # Bit fields follow the class `endian`: `little` byte-swaps the bitfield's bytes
+  # (the bitfield is read/written as a little-endian integer, fields taken from its
+  # most significant bit), while `big` / `network` / `system` / no declaration are
+  # big-endian. Pass `endian: :little` / `:big` to override a single bit field.
+  # Declare `endian` before the `bit_field` for the class default to apply.
+  #
   # Accepts the same *onlyif* / *verify* callbacks as `field`.
-  macro bit_field(onlyif = nil, verify = nil, &block)
+  macro bit_field(onlyif = nil, verify = nil, endian = nil, &block)
     {% INDEX[0] = INDEX[0] + 1 %}
     {% BIT_PARTS << {} of Nil => Nil %}
     %bitfield = @@bit_fields["{{KLASS_NAME[0]}}_{{INDEX[0]}}"] = BitField.new
@@ -559,7 +565,12 @@ abstract class BinData
     {{block.body}}
 
     %bitfield.apply
-    {% PARTS << {type: "bitfield", name: INDEX[0], cls: KLASS_NAME[0], onlyif: onlyif, verify: verify} %}
+    {% bf_endian = endian ? endian.id.stringify : ENDIAN[0] %}
+    {% if bf_endian == "little" %}
+      {% PARTS << {type: "bitfield", name: INDEX[0], cls: KLASS_NAME[0], onlyif: onlyif, verify: verify, endian: IO::ByteFormat::LittleEndian} %}
+    {% else %}
+      {% PARTS << {type: "bitfield", name: INDEX[0], cls: KLASS_NAME[0], onlyif: onlyif, verify: verify, endian: IO::ByteFormat::BigEndian} %}
+    {% end %}
   end
 
   # Declares a nested, isolated group of fields as its own `BinData` class.

--- a/src/bindata/bitfield.cr
+++ b/src/bindata/bitfield.cr
@@ -67,10 +67,7 @@ class BinData::BitField
     values = {} of String => Value
     buffer = Bytes.new(@bitsize // 8)
     input.read_fully(buffer)
-
-    # TODO:: Check if we need to re-order the bytes
-    # if format == IO::ByteFormat::LittleEndian
-    # end
+    buffer.reverse! if format == IO::ByteFormat::LittleEndian
 
     @mappings.each do |name, size|
       # Read out the data we are after using this buffer
@@ -237,7 +234,9 @@ class BinData::BitField
       end
     end
 
-    io.write(buffer[0, bytes - 1])
+    wire = buffer[0, bytes - 1]
+    wire.reverse! if format == IO::ByteFormat::LittleEndian
+    io.write(wire)
 
     0_i64
   end


### PR DESCRIPTION
## What

Adds little-endian support to bit fields. Audit tier **3.4** (#18).

## Why

`BinData::BitField` always read/wrote big-endian and ignored the declared byte
order — the `# TODO:: Check if we need to re-order the bytes / if format ==
IO::ByteFormat::LittleEndian` was unimplemented. So a `bit_field` in an
`endian little` class was silently big-endian, with no warning.

## How

- A `bit_field` whose declared endianness is `little` now byte-reverses the
  bitfield's bytes on read and write. The bitfield is treated as a little-endian
  N-byte integer with fields taken from its most-significant bit; round-trips
  hold, including fields that cross a byte boundary.
- A per-bit_field override is added: `bit_field endian: :little` / `:big` for
  mixed-endian structs (mirrors `field ..., endian:`). It takes precedence over
  the class `endian`.
- **The swap is resolved at macro-expansion time** from the declared `endian`
  string, *not* the runtime `IO::ByteFormat`. The default `__format__` is
  `SystemEndian`, which is `LittleEndian` on x86/ARM; honoring the runtime format
  would have silently byte-swapped every no-`endian` bitfield class on
  little-endian hosts. Only an explicit `little` opts in.

## Behavior change

Only classes declaring `endian little` **and** using a `bit_field` change (the
silently-wrong case). `big` / `network` / `system` / no declaration are
unchanged — bit fields were always big-endian internally, so those map to
big-endian exactly as before.

## Tests

New `spec/bindata_little_endian_bitfield_spec.cr`: byte-reverse equivalence vs the
big-endian class, round-trips, a field crossing a byte boundary, an odd 3-byte
bitfield, and both override directions. One existing `spec/bitfield_spec.cr`
assertion that passed `LittleEndian` to document the old "ignored" behavior is
updated to `BigEndian` (same expected values). Full suite green (84 examples)
under both `crystal spec` and `crystal spec -Dpreview_mt`; `crystal tool format
--check` clean; no new `ameba` findings.

## Note

Bit field endianness is order-dependent like `group`: a `bit_field` declared
before the class `endian` captures the default (big). Documented; the
`bit_field endian:` override is the explicit escape hatch.

## Docs

The README "Bit Fields" entry notes the endianness behaviour and the `bit_field endian:` override.
