### PR TITLE
fix: read remaining_bytes until EOF so it works on streaming IO

### DIFF
--- a/spec/bindata_remaining_bytes_spec.cr
+++ b/spec/bindata_remaining_bytes_spec.cr
@@ -106,4 +106,15 @@ describe BinData do
 
     io2.to_slice.should eq(io.to_slice)
   end
+
+  it "reads the remaining bytes from a non-sized (streaming) IO" do
+    reader, writer = IO.pipe
+    writer.write(Bytes[0x02, 0xAA, 0xBB, 0xCC, 0xDD])
+    writer.close
+
+    r = reader.read_bytes(RemainingBytesData)
+    r.first.should eq(0x02)
+    r.rest.should eq(Bytes[0xAA, 0xBB, 0xCC, 0xDD])
+    reader.close
+  end
 end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -274,9 +274,10 @@ abstract class BinData
             %onlyif = ({{REMAINING[0][:onlyif]}}).call
             if %onlyif
           {% end %}
-          %buf = Bytes.new io.size - io.pos
-          io.read_fully %buf
-          @{{REMAINING[0][:name]}} = %buf
+          # read every remaining byte until EOF — works on streaming IOs that
+          # don't support `size` (e.g. sockets, pipes), and equals the rest of an
+          # `IO::Memory` buffer.
+          @{{REMAINING[0][:name]}} = io.getb_to_end
           {% if REMAINING[0][:onlyif] %}
             end
           {% end %}
@@ -591,9 +592,9 @@ abstract class BinData
     {% PARTS << {type: "group", name: name.id, cls: name.id.stringify.camelcase.id, onlyif: onlyif, verify: verify, value: value} %}
   end
 
-  # Reads every remaining byte of the `IO` into a `Bytes` field. Must be the last
-  # field, and requires a sized `IO` (e.g. `IO::Memory`). Accepts *onlyif* /
-  # *verify* callbacks.
+  # Reads every remaining byte of the `IO` (until EOF) into a `Bytes` field. Must
+  # be the last field. Works with any `IO`, including streaming ones (sockets,
+  # pipes). Accepts *onlyif* / *verify* callbacks.
   macro remaining_bytes(name, onlyif = nil, verify = nil, default = nil)
     {% REMAINING << {type: "bytes", name: name.id, onlyif: onlyif, verify: verify} %}
     property {{name.id}} : Bytes = {% if default %} {{default}}.to_slice {% else %} Bytes.new(0) {% end %}


### PR DESCRIPTION
## What

Makes the `remaining_bytes` field work on streaming IOs (sockets, pipes), not just `IO::Memory`. Audit tier **3.6** (#18).

## Why

`remaining_bytes` generated `Bytes.new(io.size - io.pos); io.read_fully(...)`. `io.size` doesn't exist on a non-sized IO, and because Crystal monomorphizes the generated `__perform_read__` per concrete IO type, reading a `remaining_bytes` struct from a pipe/socket was a **compile error** (`undefined method 'size' for IO::FileDescriptor`), not just a runtime one.

## How

Read every remaining byte until EOF with `io.getb_to_end` (defined on the abstract `IO`). For an `IO::Memory` this returns exactly the rest of the buffer — identical to the old behaviour — and it also works on streaming IOs.

## Tests

New spec reads a `remaining_bytes` struct from an `IO.pipe` (a non-sized IO) and round-trips the bytes; the existing `IO::Memory` specs (including the empty-remaining case) are unchanged. Full suite green (81 examples) under both `crystal spec` and `crystal spec -Dpreview_mt`; `crystal tool format --check` clean; no new `ameba` findings. The `remaining_bytes` doc comment is updated (it no longer requires a sized IO).
