### PR TITLE
feat: reject `endian` declared after a `group`

### DIFF
--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -113,6 +113,11 @@ abstract class BinData
   # end
   # ```
   macro endian(format)
+    # A `group` captures the endianness at its declaration point, so declaring
+    # `endian` after one would silently leave it system-endian. Fail loudly.
+    {% if PARTS.any? { |part| part[:type] == "group" } %}
+      {% raise "#{@type}: `endian` must be declared before any `group`" %}
+    {% end %}
     def __format__ : IO::ByteFormat
       {% format = format.id.stringify %}
       {% ENDIAN[0] = format.id.stringify %}


### PR DESCRIPTION
## What

Turns a silent ordering footgun into a clear compile error. Audit tier **4.2** (#18).

## Why

A `group` bakes the class endianness into its nested class at its **declaration
point**, so declaring `endian` *after* a `group` silently leaves that group
system-endian (the default) instead of the intended byte order — with no warning:

```crystal
class Bad < BinData
  group :header do
    field value : UInt16   # silently system-endian
  end
  endian big               # too late for the group
end
```

## How

The `endian` macro now raises a clear compile error when a `group` was already
declared before it:

```
Bad: `endian` must be declared before any `group`
```

Declaring `endian` first (the documented convention) compiles and works as
expected; the order is no longer ambiguous.

## Notes

- This only guards `group` (the order-dependent construct today). Regular fields
  resolve their byte order at runtime via `__format__`, so they're unaffected.
- It's a compile-time guard, so it can't be a normal spec (a `{% raise %}` would
  break the suite's compilation). Verified manually that `group`-before-`endian`
  errors with the message and `endian`-before-`group` compiles and round-trips
  big-endian; the full suite (80 examples) still passes — no existing
  `endian`-first usage is falsely rejected. `crystal tool format --check` clean.
