### PR TITLE
feat: add a `skip` field (closes #4)

### DIFF
--- a/spec/bindata_skip_spec.cr
+++ b/spec/bindata_skip_spec.cr
@@ -1,0 +1,34 @@
+require "./helper"
+
+# Issue #4 — skip a run of bytes without storing them.
+class WithSkip < BinData
+  endian big
+
+  field size : UInt8
+  skip -> { size }
+  field after : UInt8
+end
+
+describe "skip" do
+  it "skips bytes on read and emits zero padding on write" do
+    io = IO::Memory.new(Bytes[0x03, 0xFF, 0xFF, 0xFF, 0x42])
+    obj = io.read_bytes(WithSkip)
+    obj.size.should eq(0x03_u8)
+    obj.after.should eq(0x42_u8)
+
+    io2 = IO::Memory.new
+    obj.write(io2)
+    io2.to_slice.should eq(Bytes[0x03, 0x00, 0x00, 0x00, 0x42])
+  end
+
+  it "skips bytes from a streaming (non-sized) IO" do
+    reader, writer = IO.pipe
+    writer.write(Bytes[0x02, 0xEE, 0xEE, 0x09])
+    writer.close
+
+    obj = reader.read_bytes(WithSkip)
+    obj.size.should eq(0x02_u8)
+    obj.after.should eq(0x09_u8)
+    reader.close
+  end
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -38,7 +38,7 @@ abstract class BinData
     "read", "write", "to_io", "from_io", "to_slice", "from_slice", "to_s", "bit_fields", "parent",
     # DSL macros
     "endian", "field", "bits", "enum_bits", "bool", "bit_field", "group",
-    "remaining_bytes", "before_serialize", "after_deserialize",
+    "remaining_bytes", "skip", "before_serialize", "after_deserialize",
     "custom", "enum_field", "array", "variable_array", "string", "bytes",
     # deprecated per-type field macros (uintN / intN / floatN and their be/le forms)
     "uint8", "uint8be", "uint8le", "int8", "int8be", "int8le",
@@ -254,6 +254,10 @@ abstract class BinData
               %value = %values[{{name.id.stringify}}]
               @{{name}} = %value.as({{value[0]}})
             {% end %}
+
+          {% elsif part[:type] == "skip" %}
+            # advance past the bytes without storing them
+            io.skip(({{part[:length]}}).call)
           {% end %}
 
           {% if part[:onlyif] %}
@@ -411,6 +415,10 @@ abstract class BinData
             {% end %}
 
             %bitfield.write(io, %endian, %values)
+
+          {% elsif part[:type] == "skip" %}
+            # nothing was stored: emit the skipped region as zero padding
+            io.write(Bytes.new(({{part[:length]}}).call))
           {% end %}
 
           {% if part[:onlyif] %}
@@ -597,6 +605,19 @@ abstract class BinData
   macro remaining_bytes(name, onlyif = nil, verify = nil, default = nil)
     {% REMAINING << {type: "bytes", name: name.id, onlyif: onlyif, verify: verify} %}
     property {{name.id}} : Bytes = {% if default %} {{default}}.to_slice {% else %} Bytes.new(0) {% end %}
+  end
+
+  # Reads and discards *length* bytes (advancing the `IO`) without storing them,
+  # for sections you don't need to keep. There is no accessor. On write the region
+  # is emitted as *length* zero bytes, so the structure round-trips to the same
+  # size. Accepts *onlyif* / *verify* callbacks.
+  #
+  # ```
+  # field section_size : UInt32
+  # skip -> { section_size - 4 }
+  # ```
+  macro skip(length, onlyif = nil, verify = nil)
+    {% PARTS << {type: "skip", name: "skip", length: length, onlyif: onlyif, verify: verify} %}
   end
 
   # this needs to be split out so we can resolve the enum base_type


### PR DESCRIPTION
## What

Adds a `skip` field that reads and discards a run of bytes without storing them. Closes #4 (open since 2020; a maintainer offered to accept a PR for it).

## Why

When parsing a format you only partly care about, you often need to advance past a section without keeping it. The current workaround is `bytes :throwaway, length: ->{ n }`, which allocates and retains the bytes. The reporter's GRIB2 use case (read a section size, skip the section, continue) is exactly this.

## How

```crystal
class GRIB2 < BinData
  endian big
  field section_size : UInt32
  skip ->{ section_size - 4 }   # advance past the section, store nothing
  field next_value : UInt16
end
```

- **read:** `io.skip(length)` — advances without allocating/storing; works on streaming IOs (sockets, pipes) too.
- **write:** nothing was stored, so the region is emitted as `length` zero bytes — the structure round-trips to the same size.
- Accepts `onlyif:` / `verify:` like other fields.
- `"skip"` is added to `RESERVED_NAMES` (so a subclass named `Skip` can't clobber the macro).

## Tests

New `spec/bindata_skip_spec.cr`: read skips the bytes and exposes the surrounding fields; write emits zero padding (`[0x03, 0xFF, 0xFF, 0xFF, 0x42]` reads → writes `[0x03, 0x00, 0x00, 0x00, 0x42]`); and a streaming `IO.pipe` case. Full suite green (82 examples) under both `crystal spec` and `crystal spec -Dpreview_mt`; format clean; no new ameba findings. The `skip` macro carries a doc comment.

> README mention will follow in a separate docs PR (the macro is already covered by `crystal docs` via its doc comment).
