### PR TITLE
fix(asn1): raise a typed error on truncated indefinite-length content

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,18 @@ Then you can specify the structures fields. There are a few different field type
    * useful when a group of fields are related or optional
 5. Enums
 6. Bools
-7. Arrays and Sets (fixed size and dynamic)
+7. Arrays and Sets — fixed size (`length:`) or variable (`read_next:`, a callback that keeps reading while it returns true)
 8. Strings (null-terminated, or fixed-size with an optional `encoding:`)
 9. Raw `Bytes`
+
+Plus a few structural helpers:
+
+* `skip ->{ n }` — advance past `n` bytes without storing them (zero-padded on write)
+* `remaining_bytes :name` — read the rest of the `IO` into a `Bytes` field (must be last)
+
+Most fields accept the callback options `onlyif:`, `verify:` and `value:`. The full
+per-macro reference (every field type and option) is in the inline API docs — run
+`crystal docs`.
 
 
 ### Examples
@@ -119,6 +128,24 @@ Failed to verify reading basic at VerifyData.checksum
 
 Inheritance is also supported
 
+## Skipping bytes
+
+When you only care about part of a structure, `skip` advances the `IO` past a run of
+bytes without storing them (handy for sections you don't need):
+
+```crystal
+class Section < BinData
+  endian big
+
+  field size : UInt32           # the section length, including these 4 bytes
+  skip ->{ size - 4 }           # discard the section body
+  field next_tag : UInt16       # carry on with what follows
+end
+```
+
+On write the skipped region is emitted as zero bytes, so the structure round-trips to
+the same size.
+
 ## Callbacks
 
 Callbacks can helpful for providing accessors for simplified representations of the data.
@@ -181,19 +208,20 @@ length field cannot force a huge allocation. The cap propagates to `children`.
 ```crystal
 ber = ASN1::BER.new
 ber.max_content_length = 64 * 1024
-ber.read(io) # raises ASN1::BER::ContentTooLarge if any element exceeds the cap
+ber.read(io) # raises ASN1::ContentTooLarge if any element exceeds the cap
 ```
 
 ## Errors
 
-Every (de)serialization error derives from `BinData::CustomException`, which carries the
-failing type and field:
+Every `BinData` (de)serialization error derives from `BinData::CustomException`, which
+carries the failing type and field:
 
 * `BinData::ParseError` / `BinData::WriteError` wrap any error hit while reading / writing a field
 * `BinData::VerificationException` is raised when a `verify:` callback returns `false`
 
-ASN.1 helpers raise `ASN1::BER::InvalidTag`, `ASN1::BER::InvalidObjectId` and
-`ASN1::BER::ContentTooLarge` for malformed input.
+The ASN.1 helpers raise `ASN1::InvalidTag`, `ASN1::InvalidObjectId`,
+`ASN1::InvalidPayload`, `ASN1::InvalidLength` and `ASN1::ContentTooLarge` for malformed
+input. They all derive from `ASN1::Error`, so `rescue ASN1::Error` catches any of them.
 
 ## Thread safety
 

--- a/spec/bindata_asn1_truncated_spec.cr
+++ b/spec/bindata_asn1_truncated_spec.cr
@@ -1,0 +1,12 @@
+require "./helper"
+
+# Audit Tier 1.2 — a truncated indefinite-length element used to surface as a raw
+# NilAssertionError (`io.read_byte.not_nil!` at EOF) instead of a typed ASN.1 error.
+
+describe "ASN1::BER truncated input" do
+  it "raises a typed error on truncated indefinite-length content" do
+    # 0x24 constructed, 0x80 indefinite length, content with no `00 00` terminator
+    io = IO::Memory.new(Bytes[0x24, 0x80, 0x01, 0x02])
+    expect_raises(ASN1::Error) { io.read_bytes(ASN1::BER) }
+  end
+end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -102,9 +102,8 @@ module ASN1
         # init to 1 as we need two 0 bytes to indicate end of stream
         previous_byte = 1_u8
         loop do
-          # NOTE: truncated input surfaces as a NilAssertionError here; a typed
-          # error is tracked separately (audit tier 1, error model).
-          current_byte = io.read_byte.not_nil! # ameba:disable Lint/NotNil
+          current_byte = io.read_byte ||
+                         raise ASN1::Error.new("unexpected end of input in indefinite-length BER content")
           break if previous_byte == 0_u8 && current_byte == 0_u8
           temp.write_byte previous_byte
           ensure_content_length(temp.pos)


### PR DESCRIPTION
## What

Replaces a raw `NilAssertionError` with a typed `ASN1::Error` when an
indefinite-length BER element is truncated. Audit tier **1.2** (#18).

## Why

The indefinite-length read loop did `current_byte = io.read_byte.not_nil!`. On a
truncated element — EOF before the `00 00` end-of-content terminator —
`read_byte` returns `nil` and `.not_nil!` raised a generic `NilAssertionError`,
which callers can't meaningfully rescue.

## How

```crystal
current_byte = io.read_byte ||
               raise ASN1::Error.new("unexpected end of input in indefinite-length BER content")
```

It now raises `ASN1::Error` (catchable alongside the other ASN.1 errors), and the
previous `# ameba:disable Lint/NotNil` annotation is dropped.

## Tests

New `spec/bindata_asn1_truncated_spec.cr`: a constructed indefinite-length element
with no terminator raises `ASN1::Error`. Full suite green (93 examples) under both
`crystal spec` and `crystal spec -Dpreview_mt`; format clean; no new ameba findings.
