### PR TITLE
feat: extend the endian-ordering guard to bit_field

### DIFF
--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -113,10 +113,10 @@ abstract class BinData
   # end
   # ```
   macro endian(format)
-    # A `group` captures the endianness at its declaration point, so declaring
-    # `endian` after one would silently leave it system-endian. Fail loudly.
-    {% if PARTS.any? { |part| part[:type] == "group" } %}
-      {% raise "#{@type}: `endian` must be declared before any `group`" %}
+    # A `group` or `bit_field` captures the endianness at its declaration point, so
+    # declaring `endian` after one would silently leave it system-endian. Fail loudly.
+    {% if PARTS.any? { |part| part[:type] == "group" || part[:type] == "bitfield" } %}
+      {% raise "#{@type}: `endian` must be declared before any `group` or `bit_field`" %}
     {% end %}
     def __format__ : IO::ByteFormat
       {% format = format.id.stringify %}


### PR DESCRIPTION
## What

Extends the "`endian` must come first" compile-time guard (added in #32 for `group`)
to also cover `bit_field`. Audit tier **4.2** (#18).

## Why

Since #30, a `bit_field` honors the class `endian` (`little` byte-swaps it), captured
at the `bit_field`'s declaration point. So declaring `endian` *after* a `bit_field`
silently leaves it big-endian — exactly the footgun the guard already rejects for
`group`:

```crystal
class Bad < BinData
  bit_field do
    bits 8, :a
  end
  endian little   # too late — the bit_field is already big-endian
end
```

## How

The `endian` macro now raises when a `group` **or** a `bit_field` was declared before
it:

```
Bad: `endian` must be declared before any `group` or `bit_field`
```

## Notes

Compile-time guard, so (like #32) it isn't a normal spec — verified manually that
`bit_field`-before-`endian` errors with the message and `endian`-before-`bit_field`
compiles and round-trips. Full suite (92 examples) still passes — no existing
`endian`-first class is falsely rejected. `crystal tool format --check` clean.
