### PR TITLE
fix: replace bare `raise "string"` with typed errors

### DIFF
--- a/spec/bindata_typed_errors_spec.cr
+++ b/spec/bindata_typed_errors_spec.cr
@@ -1,0 +1,38 @@
+require "./helper"
+
+# Audit Tier 1.3 — bare `raise "string"` replaced with typed errors:
+# BitField DSL misuse -> ArgumentError; ASN.1 errors -> the ASN1::Error hierarchy.
+
+describe "typed errors" do
+  it "raises ArgumentError for a bit field larger than 128 bits" do
+    expect_raises(ArgumentError) { BinData::BitField.new.bits(129, :x) }
+  end
+
+  it "raises ArgumentError when a bit field is not byte-aligned" do
+    bf = BinData::BitField.new
+    bf.bits 5, :x
+    expect_raises(ArgumentError) { bf.apply }
+  end
+
+  it "raises InvalidTag when asking for the universal tag of a non-universal element" do
+    ber = ASN1::BER.new
+    ber.tag_class = ASN1::BER::TagClass::Application
+    expect_raises(ASN1::InvalidTag) { ber.tag }
+  end
+
+  it "raises an ASN1::Error for a BIT STRING with unused bits" do
+    ber = ASN1::BER.new
+    ber.tag_number = ASN1::BER::UniversalTags::BitString
+    ber.payload = Bytes[0x04, 0xF0] # first byte = 4 unused bits (non-zero)
+    expect_raises(ASN1::Error) { ber.get_bitstring }
+  end
+
+  it "surfaces a too-long length indicator as a typed InvalidLength cause" do
+    # The check fires inside the `long_bytes` length proc, which runs during the
+    # generated read — so it is wrapped in ParseError with InvalidLength as cause.
+    # 0x85 = long form announcing 5 length bytes (> 4)
+    io = IO::Memory.new(Bytes[0x85, 0, 0, 0, 0, 0])
+    ex = expect_raises(BinData::ParseError) { io.read_bytes(ASN1::BER::Length) }
+    ex.cause.should be_a(ASN1::InvalidLength)
+  end
+end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -74,7 +74,7 @@ module ASN1
     # The universal tag as a `UniversalTags` enum. Raises unless this is a
     # universal-class element.
     def tag
-      raise "only valid for universal tags" unless tag_class == TagClass::Universal
+      raise ASN1::InvalidTag.new("only valid for universal tags") unless tag_class == TagClass::Universal
       UniversalTags.new tag_number.to_i
     end
 

--- a/src/bindata/asn1/data_types.cr
+++ b/src/bindata/asn1/data_types.cr
@@ -294,8 +294,8 @@ class ASN1::BER < BinData
     if @payload[0] == 0
       @payload[1, @payload.size - 1]
     else
-      # skip = @payload[0]
-      raise "skip not implemented"
+      # @payload[0] is the count of unused trailing bits — not handled yet
+      raise ASN1::Error.new("BIT STRING with unused bits is not supported")
     end
   end
 end

--- a/src/bindata/asn1/length.cr
+++ b/src/bindata/asn1/length.cr
@@ -11,7 +11,7 @@ class ASN1::BER < BinData
 
     field long_bytes : Array(UInt8), length: -> {
       if long && !indefinite?
-        raise "invalid ASN.1 BER length. Number of length bytes: #{length_indicator}" if length_indicator > 4
+        raise ASN1::InvalidLength.new("invalid ASN.1 BER length: #{length_indicator} length bytes") if length_indicator > 4
         0 | length_indicator
       else
         0

--- a/src/bindata/bitfield.cr
+++ b/src/bindata/bitfield.cr
@@ -11,13 +11,13 @@ class BinData::BitField
   end
 
   def bits(size, name)
-    raise "no support for structures larger than 128 bits" if size > 128
+    raise ArgumentError.new("no support for structures larger than 128 bits") if size > 128
     @bitsize += size
     @mappings[name.to_s] = size
   end
 
   def apply
-    raise "bit mappings must be divisible by 8" if @bitsize % 8 > 0
+    raise ArgumentError.new("bit mappings must be divisible by 8") if @bitsize % 8 > 0
   end
 
   def shift(buffer, num_bits, start_byte = 0)
@@ -141,7 +141,7 @@ class BinData::BitField
           value = value & ((1_u128 << size) - 1_u128)
         end
       else
-        raise "no support for structures larger than 128 bits"
+        raise ArgumentError.new("no support for structures larger than 128 bits")
       end
 
       # relies on integer division rounding down


### PR DESCRIPTION
## What

Replaces the remaining bare `raise "string"` calls with typed errors. Audit tier **1.3** (#18).

| Location | Was | Now |
|---|---|---|
| `BitField#bits` (size > 128), `#apply` (not byte-aligned), `#read` | bare `Exception` | `ArgumentError` (DSL misuse) |
| `ASN1::BER#tag` on a non-universal element | bare `Exception` | `ASN1::InvalidTag` |
| `ASN1::BER#get_bitstring` with non-zero unused bits | `"skip not implemented"` | `ASN1::Error` (unsupported) |
| `ASN1::BER::Length` long-form indicator > 4 | bare `Exception` | `ASN1::InvalidLength` |

## Why

Bare `raise "..."` produces a generic `Exception` callers can't rescue by type. The BitField cases are programmer/DSL-misuse errors → `ArgumentError`; the ASN.1 cases now join the `ASN1::Error` hierarchy (so `rescue ASN1::Error` catches them).

## Tests

New `spec/bindata_typed_errors_spec.cr`: `ArgumentError` for the two BitField cases, `ASN1::InvalidTag` for `#tag`, `ASN1::Error` for the BIT STRING case, and the long-form length error (which fires inside the read, so it surfaces as `ParseError` with an `InvalidLength` cause). Full suite green (97 examples) under both `crystal spec` and `crystal spec -Dpreview_mt`; format clean; no new ameba findings.
