### PR TITLE
feat!: remove the per-type field shortcut macro

### DIFF
--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -37,8 +37,7 @@ class Wow < BinData
 
   field start : UInt8, value: -> { 0_u8 }
 
-  # this is a shortcut for the `Header < BinData` class
-  header :head
+  field head : Header = Header.new
 
   group :body, onlyif: -> { head.size > 0 } do
     field start : UInt8, value: -> { 1_u8 }, onlyif: -> { parent.start == 0 }

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -21,33 +21,8 @@ require "./bindata/bitfield"
 #
 # See `#field` for the supported field types and their options.
 abstract class BinData
-  INDEX        = [-1]
-  BIT_PARTS    = [] of Nil
-  CUSTOM_TYPES = [] of BinData.class
-  # Names the per-type shortcut macro (generated in `inherited`) must never take,
-  # otherwise defining a subclass whose underscored name matches one of these
-  # would clobber a Crystal hook, a DSL macro, or a public method globally.
-  #
-  # NOTE: when adding a new DSL macro to this class, add its name here too,
-  # otherwise a subclass named after it will silently clobber it.
-  RESERVED_NAMES = [
-    # Crystal hooks / object protocol
-    "inherited", "included", "extended", "method_missing", "method_added", "finished",
-    "new", "inspect",
-    # public (de)serialization API
-    "read", "write", "to_io", "from_io", "to_slice", "from_slice", "to_s", "bit_fields", "parent",
-    # DSL macros
-    "endian", "field", "bits", "enum_bits", "bool", "bit_field", "group",
-    "remaining_bytes", "skip", "before_serialize", "after_deserialize",
-    "custom", "enum_field", "array", "variable_array", "string", "bytes",
-    # deprecated per-type field macros (uintN / intN / floatN and their be/le forms)
-    "uint8", "uint8be", "uint8le", "int8", "int8be", "int8le",
-    "uint16", "uint16be", "uint16le", "int16", "int16be", "int16le",
-    "uint32", "uint32be", "uint32le", "int32", "int32be", "int32le",
-    "uint64", "uint64be", "uint64le", "int64", "int64be", "int64le",
-    "uint128", "uint128be", "uint128le", "int128", "int128be", "int128le",
-    "float32", "float32be", "float32le", "float64", "float64be", "float64le",
-  ]
+  INDEX     = [-1]
+  BIT_PARTS = [] of Nil
 
   macro inherited
     PARTS = [] of Nil
@@ -56,16 +31,6 @@ abstract class BinData
     REMAINING = [] of Nil
     BEFORE_SERIALIZE = [] of Nil
     AFTER_DESERIALIZE = [] of Nil
-    {% BinData::CUSTOM_TYPES << @type.name.id %}
-
-    {% for custom_type in BinData::CUSTOM_TYPES %}
-    {% method_name = custom_type.gsub(/::/, "_").underscore.id %}
-      {% unless RESERVED_NAMES.includes? method_name.stringify %}
-        macro {{ method_name }}(name, onlyif = nil, verify = nil, value = nil)
-          field \{{name.id}} : {{custom_type}} = {{ custom_type }}.new
-        end
-      {% end %}
-    {% end %}
 
     def self.bit_fields
       {{@type.ancestors[0].id}}.bit_fields.merge(@@bit_fields)


### PR DESCRIPTION
Per your call on #37 ("Removal sounds good") — this removes the per-type field shortcut.

### What it was
Defining `class Header < BinData` auto-generated a `header(name)` DSL macro in the `inherited` hook, so you could write `header :head` as sugar for `field head : Header = Header.new`.

### Why remove it
- **O(n²) at compile time.** Each subclass pushed itself onto a class-level `CUSTOM_TYPES` array that was re-iterated *in full* on every subsequent `inherited`, regenerating one macro per known type for each new class.
- **Namespace pollution.** The generated macro could clobber a Crystal hook, a DSL macro or a public method — which is exactly why the hand-maintained `RESERVED_NAMES` blocklist (tier 4.4 in the audit) had to shadow every such name. Removing the shortcut removes the whole class of collision.

### The change
- Drop the `CUSTOM_TYPES` and `RESERVED_NAMES` constants and the generation loop from `BinData`'s `inherited` macro.
- Migrate the one in-repo use (`header :head` in the spec helper) to the explicit `field head : Header = Header.new` — which is what the shortcut expanded to anyway, so accessors and behaviour are unchanged.

The normal `field` macro is untouched and independent — the ASN.1 layer (`field identifier : Identifier`, `field length : Length`) is unaffected.

### Breaking
`<TypeName> :name` is removed; callers use `field name : TypeName = TypeName.new`. Hence the `!` / major bump.

`crystal spec`: 98 examples, 0 failures. `crystal tool format --check`: clean.

Closes #37. Part of #18 — this was the last open item in the audit.