### PR TITLE
fix(asn1): make the INTEGER codec correct and Int64-bounded

### DIFF
--- a/spec/bindata_asn1_integer_spec.cr
+++ b/spec/bindata_asn1_integer_spec.cr
@@ -1,0 +1,59 @@
+require "./helper"
+
+# `get_integer` returns `Int64`. An INTEGER whose content does not fit `Int64`
+# (more than 8 significant bytes) used to be decoded with `byte << (8 * index)`
+# where the shift count reaches 64+, and `Int64 << 64 == 0` in Crystal — so a
+# 9-byte `2^64` silently returned 0 and a 10-byte value returned -1. Reject it
+# with a typed error instead of mis-decoding.
+private def int_ber(payload : Bytes, tag = ASN1::BER::UniversalTags::Integer)
+  ber = ASN1::BER.new
+  ber.tag_number = tag
+  ber.payload = payload
+  ber
+end
+
+describe "ASN1::BER#get_integer Int64 bounds" do
+  it "decodes the full 8-byte Int64::MAX" do
+    int_ber(Bytes[0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).get_integer.should eq(Int64::MAX)
+  end
+
+  it "decodes the full 8-byte Int64::MIN" do
+    int_ber(Bytes[0x80, 0, 0, 0, 0, 0, 0, 0]).get_integer.should eq(Int64::MIN)
+  end
+
+  it "raises InvalidPayload on a 9-byte INTEGER that overflows Int64" do
+    # 0x01 followed by 8 zero bytes == 2^64, unrepresentable in Int64
+    expect_raises(ASN1::InvalidPayload) { int_ber(Bytes[0x01, 0, 0, 0, 0, 0, 0, 0, 0]).get_integer }
+  end
+
+  it "raises InvalidPayload on a 10-byte INTEGER" do
+    expect_raises(ASN1::InvalidPayload) do
+      int_ber(Bytes[0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).get_integer
+    end
+  end
+
+  it "round-trips representative values through set_integer/get_integer" do
+    [0_i64, 1_i64, -1_i64, 127_i64, 128_i64, 255_i64, 256_i64, -128_i64, -129_i64,
+     32767_i64, -32768_i64, 1234567890123_i64, -1234567890123_i64, Int64::MAX, Int64::MIN].each do |n|
+      ber = ASN1::BER.new
+      ber.set_integer(n)
+      io = IO::Memory.new
+      ber.write(io)
+      io.rewind
+      io.read_bytes(ASN1::BER).get_integer.should eq(n)
+    end
+  end
+
+  it "decodes an Enumerated payload as an integer" do
+    int_ber(Bytes[0x05], ASN1::BER::UniversalTags::Enumerated).get_integer.should eq(5_i64)
+  end
+
+  it "rejects on read a value written from an unsigned integer that overflows Int64" do
+    # set_integer encodes UInt64::MAX as a valid 9-byte unsigned INTEGER, which
+    # cannot be represented in the Int64 get_integer returns — read must reject,
+    # not silently corrupt. Locks in write-side/read-side consistency.
+    ber = ASN1::BER.new
+    ber.set_integer(UInt64::MAX)
+    expect_raises(ASN1::InvalidPayload) { ber.get_integer }
+  end
+end

--- a/src/bindata/asn1/data_types.cr
+++ b/src/bindata/asn1/data_types.cr
@@ -198,6 +198,11 @@ class ASN1::BER < BinData
     raise InvalidTag.new("object is a #{tag}, expecting one of #{check_tags}") unless check_tags.includes?(tag)
     return 0_i64 if @payload.size == 0
 
+    # An INTEGER wider than 8 bytes cannot be represented in the Int64 this
+    # returns; the bit-shift below would reach a shift count of 64+ (which is 0
+    # in Crystal) and silently mis-decode. Reject it instead.
+    raise InvalidPayload.new("INTEGER content of #{@payload.size} bytes exceeds Int64 range") if @payload.size > 8
+
     # Check if first bit is set indicating negativity
     negative = (@payload[0] & 0x80) > 0
     reverse_index = @payload.size - 1
@@ -217,7 +222,9 @@ class ASN1::BER < BinData
       reverse_index -= 1
     end
 
-    return -(start + 1) if negative
+    # `-start - 1`, not `-(start + 1)`: for Int64::MIN the magnitude `start`
+    # reaches Int64::MAX, so `start + 1` would overflow before the negation.
+    return -start - 1 if negative
     start
   end
 
@@ -274,11 +281,20 @@ class ASN1::BER < BinData
     # ensure there is at least one byte
     bytes.write_byte(negative ? 0xFF_u8 : 0x00_u8) if bytes.size == 0
 
-    # Make sure positive integers don't start with 0xFF
+    # Preserve the sign bit. A positive value whose top bit is set needs a 0x00
+    # pad so it doesn't decode as negative; symmetrically, a negative value whose
+    # top bit is clear needs a 0xFF pad so it doesn't decode as positive (e.g.
+    # -129 is 0xFF 0x7F, not 0x7F). Without the negative pad, stripping the
+    # leading 0xFF sign bytes above flips the sign.
     payload_bytes = bytes.to_slice
-    if !negative && (payload_bytes[0] & 0b10000000) > 0
+    pad = if !negative && (payload_bytes[0] & 0x80) > 0
+            0x00_u8
+          elsif negative && (payload_bytes[0] & 0x80) == 0
+            0xFF_u8
+          end
+    if pad
       io = IO::Memory.new
-      io.write_bytes 0x00_u8
+      io.write_byte pad
       io.write payload_bytes
       payload_bytes = io.to_slice
     end


### PR DESCRIPTION
Three latent defects in the hand-rolled two's-complement INTEGER codec (`src/bindata/asn1/data_types.cr`), all in the same class of bug — found while re-auditing the codec, reproduced, fixed together.

### 1. `get_integer` silently mis-decodes INTEGERs wider than 8 bytes
The decode does `byte << (8 * index)`. For a payload > 8 bytes the shift count reaches 64+, and `Int64 << 64 == 0` in Crystal — so the high bytes vanish:

```crystal
get_integer(2^64  as 9 bytes) # => 0   (should not be representable)
get_integer(10-byte value)    # => -1
```

Such a value can't fit the `Int64` this returns. Now raises `ASN1::InvalidPayload`. (8 content bytes is always sufficient for any in-range Int64, so the guard never rejects a representable value.)

### 2. `get_integer` raises `OverflowError` on `Int64::MIN`
The final negative return was `-(start + 1)`; for `Int64::MIN` the magnitude `start` reaches `Int64::MAX`, so `start + 1` overflows before the negation. Computing `-start - 1` stays in range and yields `Int64::MIN`.

### 3. `set_integer` flips the sign of certain negatives
Encoding stripped *all* leading `0xFF` sign bytes but never re-added the pad needed to keep the value negative — the mirror of the positive `0x00` pad it already does. So `-129` (minimal `FF 7F`) was emitted as `7F` and round-tripped to **+127**; `-256` → `00` → 0; etc. Added the symmetric `0xFF` pad.

### Tests
New `spec/bindata_asn1_integer_spec.cr`: full 8-byte `Int64::MAX`/`MIN` decode, 9- and 10-byte rejection, `Enumerated` decode, a representative `set_integer`→`get_integer` round-trip (incl. ±128/±129, `Int64::MAX`/`MIN`), and write/read consistency for a `UInt64` value that overflows `Int64`. Existing INTEGER read/write specs (`bindata_asn1_spec.cr:116-178`) still pass unchanged — the negative pad only adds a byte when the stripped top byte has its high bit clear.

`crystal spec`: 105 examples, 0 failures. `crystal tool format --check`: clean.

Part of #18 (robustness / error model, tier 1.x). These were not in the original audit — surfaced by a deeper pass on the INTEGER codec, the most corruption-prone hand-rolled decoder in the library.