### PR TITLE
perf(bitfield): decode <=16-bit fields without a per-field IO::Memory

### DIFF
--- a/src/bindata/bitfield.cr
+++ b/src/bindata/bitfield.cr
@@ -70,12 +70,11 @@ class BinData::BitField
     buffer.reverse! if format == IO::ByteFormat::LittleEndian
 
     @mappings.each do |name, size|
-      # Read out the data we are after using this buffer
-      io = IO::Memory.new(buffer)
-      io.rewind
-
+      # Fields up to 16 bits (every BER identifier and length goes through here)
+      # decode straight from the buffer slice — no per-field IO::Memory in this
+      # hot loop. The wider cases below still wrap the buffer so they can pad it.
       if size <= 8
-        value = io.read_bytes(UInt8, IO::ByteFormat::BigEndian)
+        value = buffer[0]
 
         if size < 8
           # Shift the bits we're interested in towards 0 (as they are high bits)
@@ -84,7 +83,7 @@ class BinData::BitField
           value = value & ((1_u8 << size) - 1_u8)
         end
       elsif size <= 16
-        value = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+        value = IO::ByteFormat::BigEndian.decode(UInt16, buffer)
 
         if size < 16
           # Shift the bits we're interested in towards 0 (as they are high bits)
@@ -93,6 +92,7 @@ class BinData::BitField
           value = value & ((1_u16 << size) - 1_u16)
         end
       elsif size <= 32
+        io = IO::Memory.new(buffer)
         # adjust buffer as required to read the value
         if (io.size - io.pos) < 4
           io_new = IO::Memory.new(Bytes.new(4))
@@ -109,6 +109,7 @@ class BinData::BitField
           value = value & ((1_u32 << size) - 1_u32)
         end
       elsif size <= 64
+        io = IO::Memory.new(buffer)
         # adjust buffer as required to read the value
         if (io.size - io.pos) < 8
           io_new = IO::Memory.new(Bytes.new(8))
@@ -125,6 +126,7 @@ class BinData::BitField
           value = value & ((1_u64 << size) - 1_u64)
         end
       elsif size <= 128
+        io = IO::Memory.new(buffer)
         # adjust buffer as required to read the value
         if (io.size - io.pos) < 16
           io_new = IO::Memory.new(Bytes.new(16))


### PR DESCRIPTION
Closes the last open audit item (tier 5.5, the only perf finding).

`BitField#read` allocated a fresh `IO::Memory.new(buffer)` on **every** iteration of the field loop, then read from offset 0. Fields that fit in 8 or 16 bits don't need it — and that covers every ASN.1 BER **identifier** and **length**, the hottest decode path in the library (two bit-field reads per BER element).

### Change
- `size <= 8` → `value = buffer[0]`
- `size <= 16` → `value = IO::ByteFormat::BigEndian.decode(UInt16, buffer)` (verified: `decode` reads `sizeof(T)` bytes from the front of the slice)
- the `32`/`64`/`128`-bit branches are unchanged except each now creates its `IO::Memory` locally (they still wrap the buffer to pad a short tail). The pad + shift logic is byte-for-byte identical.

### Impact
Measured on a 2-field 8-bit bit field (the BER length/identifier shape): **~1792 → ~1312 bytes/read (~27% less)**. The removed allocations were `O(fields)` per read.

### Safety
- `crystal spec`: 98 examples, 0 failures — single-threaded **and** under `-Dpreview_mt`.
- A `32`/`64`/`128`/`12`/`4`-bit round-trip (including a non-byte-aligned field, which exercises `shift`) verifies the untouched wide branches.
- No public API or behaviour change.

Part of #18 (tier 5.5).