### PR TITLE
fix(asn1): don't prepend a sentinel byte to indefinite-length payloads

### DIFF
--- a/spec/bindata_asn1_indefinite_spec.cr
+++ b/spec/bindata_asn1_indefinite_spec.cr
@@ -1,0 +1,33 @@
+require "./helper"
+
+# Indefinite-length BER: the payload is everything up to the terminating 00 00.
+# The reader uses one byte of look-ahead to avoid writing the terminator; it must
+# not prepend a sentinel byte to the content (it used to seed the look-ahead with
+# 0x01, which leaked into the payload).
+describe "ASN1::BER indefinite-length content" do
+  it "reads the exact content of an indefinite-length element" do
+    # 0x24 constructed OctetString, 0x80 indefinite, inner TLV 04 03 'A' 'B' 'C', 00 00
+    io = IO::Memory.new(Bytes[0x24, 0x80, 0x04, 0x03, 0x41, 0x42, 0x43, 0x00, 0x00])
+    ber = io.read_bytes(ASN1::BER)
+    ber.payload.should eq(Bytes[0x04, 0x03, 0x41, 0x42, 0x43])
+  end
+
+  it "reads an empty indefinite-length payload" do
+    io = IO::Memory.new(Bytes[0x24, 0x80, 0x00, 0x00])
+    io.read_bytes(ASN1::BER).payload.empty?.should be_true
+  end
+
+  it "preserves a 0x00 content byte that is not part of the terminator" do
+    # content is 00 05 (a lone 0x00 followed by a non-zero byte), then 00 00
+    io = IO::Memory.new(Bytes[0x24, 0x80, 0x00, 0x05, 0x00, 0x00])
+    io.read_bytes(ASN1::BER).payload.should eq(Bytes[0x00, 0x05])
+  end
+
+  it "round-trips children through an indefinite-length frame" do
+    io = IO::Memory.new(Bytes[0x24, 0x80, 0x04, 0x03, 0x41, 0x42, 0x43, 0x00, 0x00])
+    ber = io.read_bytes(ASN1::BER)
+    child = ber.children.first
+    child.tag.should eq(ASN1::BER::UniversalTags::OctetString)
+    String.new(child.payload).should eq("ABC")
+  end
+end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -99,8 +99,11 @@ module ASN1
       super(io)
       if @length.indefinite?
         temp = IO::Memory.new
-        # init to 1 as we need two 0 bytes to indicate end of stream
-        previous_byte = 1_u8
+        # Read with one byte of look-ahead so the terminating `00 00` is detected
+        # without being written into the payload. Seed with the first content byte
+        # itself — seeding with a fake sentinel would prepend it to the payload.
+        previous_byte = io.read_byte ||
+                        raise ASN1::Error.new("unexpected end of input in indefinite-length BER content")
         loop do
           current_byte = io.read_byte ||
                          raise ASN1::Error.new("unexpected end of input in indefinite-length BER content")


### PR DESCRIPTION
The indefinite-length BER reader corrupted every payload it decoded by prepending a stray `0x01`.

### The bug
The reader uses one byte of look-ahead to detect the terminating `00 00` without writing it. But it seeded the look-ahead with a fake sentinel `previous_byte = 1` and then wrote `previous_byte` on every iteration — so the sentinel `0x01` landed in the payload before the real content:

```crystal
io = IO::Memory.new(Bytes[0x24, 0x80, 0x04, 0x03, 0x41, 0x42, 0x43, 0x00, 0x00])
io.read_bytes(ASN1::BER).payload
# => Bytes[1, 4, 3, 65, 66, 67]     ✗  (a leading 0x01 that was never on the wire)
# expected Bytes[4, 3, 65, 66, 67]
```

This silently corrupts the content of **every** constructed indefinite-length element, and breaks `children` on them (the leading byte shifts the whole TLV stream). Indefinite-length encoding is used by streaming BER producers (some LDAP/SNMP stacks).

### The fix
Seed the look-ahead with the **first content byte** read from the stream, not a sentinel. One line of intent, same terminator detection.

### Tests
New `spec/bindata_asn1_indefinite_spec.cr`: exact-content read, empty payload (`00 00` immediately), a content `0x00` that isn't part of the terminator, and a `children` round-trip through an indefinite frame. The existing failure-path specs (`bindata_asn1_truncated_spec.cr`, `bindata_asn1_dos_spec.cr` — truncated / no-terminator → typed error / `ContentTooLarge`) still pass unchanged.

`crystal spec`: 102 examples, 0 failures. Format clean.

Part of #18 (tier 1.x / 3.x — protocol correctness). Not in the original audit; surfaced by adding the indefinite-length happy-path coverage that was missing.