### PR TITLE
fix(security): reject negative length:/skip callback results

### DIFF
--- a/spec/bindata_negative_length_spec.cr
+++ b/spec/bindata_negative_length_spec.cr
@@ -1,0 +1,49 @@
+require "./helper"
+
+# Security/robustness: a `length:` / `skip` callback whose result comes from the
+# wire must not produce a negative size. A negative `array` length used to read
+# zero elements silently; a negative `skip` used to move the cursor backwards
+# (re-reading attacker bytes / desyncing the stream). Both must raise a typed
+# `BinData::ParseError` instead.
+
+class NegArray < BinData
+  endian big
+  field n : Int8
+  field items : Array(UInt8), length: -> { n.to_i }
+end
+
+class NegBytes < BinData
+  endian big
+  field n : Int8
+  field data : Bytes, length: -> { n.to_i }
+end
+
+class NegSkip < BinData
+  endian big
+  field n : Int8
+  skip -> { n.to_i }
+  field tail : UInt8
+end
+
+describe "negative length / skip guard" do
+  it "raises on a negative array length instead of silently reading nothing" do
+    io = IO::Memory.new(Bytes[0xFF, 0x01, 0x02, 0x03]) # n = -1
+    expect_raises(BinData::ParseError) { io.read_bytes(NegArray) }
+  end
+
+  it "raises on a negative bytes length" do
+    io = IO::Memory.new(Bytes[0xFF, 0x01, 0x02]) # n = -1
+    expect_raises(BinData::ParseError) { io.read_bytes(NegBytes) }
+  end
+
+  it "raises on a negative skip instead of moving the cursor backwards" do
+    io = IO::Memory.new(Bytes[0xFF, 0xAA]) # n = -1
+    expect_raises(BinData::ParseError) { io.read_bytes(NegSkip) }
+  end
+
+  it "still reads a normal (non-negative) array" do
+    io = IO::Memory.new(Bytes[0x02, 0x0A, 0x0B])
+    r = io.read_bytes(NegArray)
+    r.items.should eq([0x0A_u8, 0x0B_u8])
+  end
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -138,6 +138,18 @@ abstract class BinData
     inspect(io)
   end
 
+  # Validates a `length:` / `skip` callback result before it is used to allocate
+  # a buffer or advance the cursor. The value is typically derived from an
+  # attacker-controlled wire field; a negative size would otherwise silently read
+  # zero elements (`array`) or move the cursor backwards (`skip`), desyncing the
+  # stream. Raised errors are wrapped in `ParseError` with the field name.
+  protected def __read_length__(value) : Int32
+    raise ArgumentError.new("length/skip callback returned nil") if value.nil?
+    size = value.to_i
+    raise ArgumentError.new("length/skip callback returned a negative value: #{size}") if size < 0
+    size
+  end
+
   macro __build_methods__
     protected def __perform_read__(io : IO) : IO
       # Support inheritance
@@ -170,7 +182,7 @@ abstract class BinData
             {% end %}
 
           {% elsif part[:type] == "array" %}
-            %size = ({{part[:length]}}).call.not_nil!
+            %size = __read_length__(({{part[:length]}}).call)
             @{{part[:name]}} = [] of {{part[:cls]}}
             (0...%size).each do
               @{{part[:name]}} << io.read_bytes({{part[:cls]}}, %endian)
@@ -194,7 +206,7 @@ abstract class BinData
 
           {% elsif part[:type] == "bytes" %}
             # There is a length calculation
-            %size = ({{part[:length]}}).call.not_nil!
+            %size = __read_length__(({{part[:length]}}).call)
             %buf = Bytes.new(%size)
             io.read_fully(%buf)
             @{{part[:name]}} = %buf
@@ -202,7 +214,7 @@ abstract class BinData
           {% elsif part[:type] == "string" %}
             {% if part[:length] %}
               # There is a length calculation
-              %size = ({{part[:length]}}).call.not_nil!
+              %size = __read_length__(({{part[:length]}}).call)
               %buf = Bytes.new(%size)
               io.read_fully(%buf)
               {% if part[:encoding] %}
@@ -227,7 +239,7 @@ abstract class BinData
 
           {% elsif part[:type] == "skip" %}
             # advance past the bytes without storing them
-            io.skip(({{part[:length]}}).call)
+            io.skip(__read_length__(({{part[:length]}}).call))
           {% end %}
 
           {% if part[:onlyif] %}


### PR DESCRIPTION
First of the **P-SEC** (security) items from #44 — the clean, non-breaking ones.

A `length:` (array/bytes/string) or `skip` callback usually derives its value from a wire field the attacker controls. A negative result was handled unsafely:

- **`array`** with a negative length silently read **zero** elements (`(0...size)` is an empty range) — silent parse truncation.
- **`skip`** with a negative length moved the cursor **backwards** (`io.skip(-n)`), re-reading already-consumed attacker bytes and **desyncing the stream** (verified: pos 4 → 2).
- **`bytes`/`string`** raised an opaque `ArgumentError` from `Bytes.new(neg)`.

### Fix
Route all four sites through a `__read_length__` helper that rejects a negative (or nil) size with an error wrapped as `BinData::ParseError`, naming the offending field. Non-negative reads are byte-for-byte unchanged.

### Tests
`spec/bindata_negative_length_spec.cr`: negative `array`/`bytes`/`skip` → `ParseError`; a normal array still round-trips.

`crystal spec`: 124 examples, 0 failures. Format clean. Non-breaking (negative sizes were always a bug).

Part of #44 (P-SEC). Does **not** address the positive-but-huge allocation cap or the `strict`/DER items — those are separate (and the latter need a design decision).