### PR TITLE
fix(security): cap generic-DSL allocations with max_content_length

### DIFF
--- a/spec/bindata_dos_spec.cr
+++ b/spec/bindata_dos_spec.cr
@@ -1,0 +1,145 @@
+require "./helper"
+
+# P-SEC #1 / #5 — the generic DSL trusts an attacker-controlled `length:` before
+# allocating, so a tiny hostile message can force a huge `Bytes`/`Array`
+# allocation (verified ~50 MB from a single wire byte), and a non-advancing
+# `variable_array` element loops forever. An opt-in per-instance
+# `max_content_length` cap (default `0` = unlimited, so existing behaviour is
+# unchanged) guards every generic allocation site and propagates into nested
+# `BinData` children so a small frame cannot smuggle an oversized one.
+
+private class GreedyBytes < BinData
+  endian big
+  field len : UInt32
+  field payload : Bytes, length: -> { len.to_i }
+end
+
+private class GreedyString < BinData
+  endian big
+  field len : UInt32
+  field text : String, length: -> { len.to_i }
+end
+
+private class CountedBytes < BinData
+  endian big
+  field count : UInt32
+  field nums : Array(UInt8), length: -> { count.to_i }
+end
+
+private class Inner < BinData
+  endian big
+  field len : UInt32
+  field payload : Bytes, length: -> { len.to_i }
+end
+
+private class NestedArray < BinData
+  endian big
+  field count : UInt32
+  field items : Array(Inner), length: -> { count.to_i }
+end
+
+private class NestedBasic < BinData
+  endian big
+  field inner : Inner = Inner.new
+end
+
+private class WithGroup < BinData
+  endian big
+  group :g do
+    field len : UInt32
+    field payload : Bytes, length: -> { len.to_i }
+  end
+end
+
+private class Empty < BinData
+end
+
+private class Loopy < BinData
+  field items : Array(Empty), read_next: -> { true }
+end
+
+# variable_array of nested BinData: the cap must propagate into each element so
+# an oversized inner field is rejected mid-stream.
+private class VarNested < BinData
+  endian big
+  field items : Array(Inner), read_next: -> { true }
+end
+
+private def read_capped(klass : T.class, bytes : Bytes, cap : Int32) : T forall T
+  obj = klass.new
+  obj.max_content_length = cap
+  obj.read(IO::Memory.new(bytes))
+  obj
+end
+
+describe "BinData max_content_length" do
+  it "defaults to 0 (unlimited), leaving existing behaviour unchanged" do
+    GreedyBytes.new.max_content_length.should eq(0)
+
+    obj = IO::Memory.new(Bytes[0, 0, 0, 3, 1, 2, 3]).read_bytes(GreedyBytes)
+    obj.payload.should eq(Bytes[1, 2, 3])
+  end
+
+  it "reads a normal frame that fits within the cap" do
+    obj = read_capped(GreedyBytes, Bytes[0, 0, 0, 3, 1, 2, 3], 1024)
+    obj.payload.should eq(Bytes[1, 2, 3])
+  end
+
+  it "allows a length exactly equal to the cap (inclusive boundary)" do
+    obj = read_capped(GreedyBytes, Bytes[0, 0, 0, 3, 1, 2, 3], 3)
+    obj.payload.should eq(Bytes[1, 2, 3])
+  end
+
+  it "rejects an oversized Bytes length before allocating" do
+    # len = 0x7FFFFFFF (~2 GiB), no payload actually follows.
+    frame = Bytes[0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(GreedyBytes, frame, 1024) }
+  end
+
+  it "rejects an oversized String length before allocating" do
+    frame = Bytes[0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(GreedyString, frame, 1024) }
+  end
+
+  it "rejects an oversized array element count before allocating" do
+    # count = 0x7FFFFFFF; the cap fires before any per-element read.
+    frame = Bytes[0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(CountedBytes, frame, 1024) }
+  end
+
+  it "propagates the cap into nested BinData array elements (no smuggling)" do
+    # count = 1, then an Inner announcing ~2 GiB. The outer frame is tiny.
+    frame = Bytes[0, 0, 0, 1, 0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(NestedArray, frame, 1024) }
+  end
+
+  it "propagates the cap into a nested BinData field" do
+    frame = Bytes[0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(NestedBasic, frame, 1024) }
+  end
+
+  it "propagates the cap into a group" do
+    frame = Bytes[0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(WithGroup, frame, 1024) }
+  end
+
+  it "propagates the cap into variable_array BinData elements" do
+    # One Inner that fits, then a second announcing ~2 GiB; read_next stays true.
+    frame = Bytes[0, 0, 0, 0, 0x7F, 0xFF, 0xFF, 0xFF]
+    expect_raises(BinData::ContentTooLarge) { read_capped(VarNested, frame, 1024) }
+  end
+
+  it "never raises with no cap, even for a large declared length present on the wire" do
+    # 4-byte length header (len = 4) + 4 payload bytes; the default cap of 0 must
+    # leave this untouched.
+    obj = IO::Memory.new(Bytes[0, 0, 0, 4, 9, 9, 9, 9]).read_bytes(GreedyBytes)
+    obj.payload.should eq(Bytes[9, 9, 9, 9])
+    obj.max_content_length.should eq(0)
+  end
+
+  it "bounds a non-advancing variable_array under a cap" do
+    # `read_next` is always true and `Empty` consumes no bytes: without a cap
+    # this loops forever. The cap turns it into a bounded failure.
+    expect_raises(BinData::ContentTooLarge) { read_capped(Loopy, Bytes.new(0), 100) }
+  end
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -47,6 +47,19 @@ abstract class BinData
     @@bit_fields
   end
 
+  # Maximum number of bytes/elements any single field of this instance (and its
+  # nested `BinData` children) may allocate or read. `0`, the default, means
+  # unlimited, so existing behaviour is unchanged. Set a positive cap before
+  # reading untrusted input to guard against allocation/exhaustion DoS:
+  #
+  #     packet = Packet.new
+  #     packet.max_content_length = 64 * 1024
+  #     packet.read(io)
+  #
+  # The cap propagates into nested `group`/`array` `BinData` children so a small
+  # frame cannot smuggle an oversized one.
+  property max_content_length : Int32 = 0
+
   def __format__ : IO::ByteFormat
     IO::ByteFormat::SystemEndian
   end
@@ -150,6 +163,17 @@ abstract class BinData
     size
   end
 
+  # Enforces `max_content_length` against a size/count derived from the wire
+  # before it is used to allocate a buffer, size an array, or bound a loop. A
+  # cap of `0` (the default) is unlimited. Returns *size* unchanged when allowed.
+  protected def __enforce_content_length__(size : Int32) : Int32
+    return size if @max_content_length <= 0
+    if size > @max_content_length
+      raise ContentTooLarge.new("content length #{size} exceeds max_content_length #{@max_content_length}")
+    end
+    size
+  end
+
   macro __build_methods__
     protected def __perform_read__(io : IO) : IO
       # Support inheritance
@@ -177,23 +201,49 @@ abstract class BinData
               @{{part[:name]}} = io.read_bytes({{part_type.types.reject(&.nilable?)[0]}}, %endian)
             {% elsif part_type.union? %}
               @{{part[:name]}} = io.read_bytes({{part_type.union_types.reject(&.nilable?)[0]}}, %endian)
+            {% elsif part_type < BinData %}
+              # Nested BinData: read explicitly so the content cap propagates
+              # (a small frame must not smuggle an oversized child).
+              %nested = {{part[:cls]}}.new
+              %nested.max_content_length = @max_content_length
+              %nested.read(io)
+              @{{part[:name]}} = %nested
             {% else %}
               @{{part[:name]}} = io.read_bytes({{part[:cls]}}, %endian)
             {% end %}
 
           {% elsif part[:type] == "array" %}
-            %size = __read_length__(({{part[:length]}}).call)
+            %size = __enforce_content_length__(__read_length__(({{part[:length]}}).call))
             @{{part[:name]}} = [] of {{part[:cls]}}
             (0...%size).each do
-              @{{part[:name]}} << io.read_bytes({{part[:cls]}}, %endian)
+              {% if part[:cls].resolve < BinData %}
+                %element = {{part[:cls]}}.new
+                %element.max_content_length = @max_content_length
+                %element.read(io)
+                @{{part[:name]}} << %element
+              {% else %}
+                @{{part[:name]}} << io.read_bytes({{part[:cls]}}, %endian)
+              {% end %}
             end
 
           {% elsif part[:type] == "variable_array" %}
             @{{part[:name]}} = [] of {{part[:cls]}}
+            %count = 0
             loop do
               # Stop if the callback indicates there is no more
               break unless ({{part[:read_next]}}).call
-              @{{part[:name]}} << io.read_bytes({{part[:cls]}}, %endian)
+              # Bound the loop under a cap so a non-advancing element can't spin
+              # forever. With no cap the counter is left untouched, so behaviour
+              # (and the unbounded loop) is exactly as before.
+              __enforce_content_length__(%count += 1) if @max_content_length > 0
+              {% if part[:cls].resolve < BinData %}
+                %element = {{part[:cls]}}.new
+                %element.max_content_length = @max_content_length
+                %element.read(io)
+                @{{part[:name]}} << %element
+              {% else %}
+                @{{part[:name]}} << io.read_bytes({{part[:cls]}}, %endian)
+              {% end %}
             end
 
           {% elsif part[:type] == "enum" %}
@@ -202,11 +252,12 @@ abstract class BinData
           {% elsif part[:type] == "group" %}
             @{{part[:name]}} = {{part[:cls]}}.new
             @{{part[:name]}}.parent = self
+            @{{part[:name]}}.max_content_length = @max_content_length
             @{{part[:name]}}.read(io)
 
           {% elsif part[:type] == "bytes" %}
             # There is a length calculation
-            %size = __read_length__(({{part[:length]}}).call)
+            %size = __enforce_content_length__(__read_length__(({{part[:length]}}).call))
             %buf = Bytes.new(%size)
             io.read_fully(%buf)
             @{{part[:name]}} = %buf
@@ -214,7 +265,7 @@ abstract class BinData
           {% elsif part[:type] == "string" %}
             {% if part[:length] %}
               # There is a length calculation
-              %size = __read_length__(({{part[:length]}}).call)
+              %size = __enforce_content_length__(__read_length__(({{part[:length]}}).call))
               %buf = Bytes.new(%size)
               io.read_fully(%buf)
               {% if part[:encoding] %}

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -37,15 +37,9 @@ module ASN1
     field length : Length = Length.new
     property payload : Bytes = Bytes.new(0)
 
-    # Maximum number of payload bytes this object (and its children) may
-    # allocate or read. `0`, the default, means unlimited. Set a positive cap
-    # before reading untrusted input to guard against allocation/exhaustion DoS,
-    # reading the root explicitly so the cap is in place before parsing:
-    #
-    #     ber = ASN1::BER.new
-    #     ber.max_content_length = 64 * 1024
-    #     ber.read(io)
-    property max_content_length : Int32 = 0
+    # `max_content_length` is inherited from `BinData`; reading the root
+    # explicitly (rather than via `IO#read_bytes`) lets a cap be set before
+    # parsing, and `#children` propagates it to nested elements.
 
     def tag_class
       @identifier.tag_class
@@ -133,7 +127,10 @@ module ASN1
     private def ensure_content_length(size)
       return if @max_content_length <= 0
       if size > @max_content_length
-        raise ContentTooLarge.new("ASN.1 content length #{size} exceeds max_content_length #{@max_content_length}")
+        # Fully qualified: `BinData::ContentTooLarge` (an ancestor constant) would
+        # otherwise shadow this in BER's lexical scope, breaking the typed
+        # `ASN1::Error` contract.
+        raise ASN1::ContentTooLarge.new("ASN.1 content length #{size} exceeds max_content_length #{@max_content_length}")
       end
     end
 

--- a/src/bindata/exceptions.cr
+++ b/src/bindata/exceptions.cr
@@ -37,6 +37,10 @@ abstract class BinData
     def initialize(@klass, @field, ex : Exception)
       super("Failed to parse #{klass}.#{field}", ex)
     end
+
+    def initialize(message)
+      super(message)
+    end
   end
 
   # Wraps any error raised while writing a field, tagged with its location.
@@ -45,4 +49,9 @@ abstract class BinData
       super("Failed to write #{klass}.#{field}", ex)
     end
   end
+
+  # Raised when a field would allocate or read more than `BinData#max_content_length`
+  # permits. A `ParseError` so it surfaces through the normal read error path
+  # without being re-wrapped.
+  class ContentTooLarge < ParseError; end
 end


### PR DESCRIPTION
Implements item **1** (allocation cap) from the security pass in #44 — the one you confirmed (*"1 yes, non-breaking change is important"*). Also folds in P-SEC #5 (non-advancing `variable_array` loop).

## Problem
The declarative DSL trusted an attacker-controlled `length:` callback before allocating, so a tiny hostile message could force a huge `Bytes`/`Array` allocation (verified ~50 MB from a single wire byte, scaling to GBs), and a non-advancing `variable_array` element looped forever. Only `ASN1::BER` had a `max_content_length` guard; the generic DSL had none.

## Change
- **Lift `max_content_length` onto the `BinData` base**, default `0` = unlimited → **non-breaking**, existing behaviour byte-identical. `ASN1::BER` now inherits it (its duplicate property removed).
- **Enforce before every generic allocation site**: `bytes`, fixed-length `string`, `array` element count, and the `variable_array` loop (the counter only runs under an active cap, so `cap == 0` is exactly the old loop).
- **Propagate the cap into nested `BinData` children** — `group`, `array`/`variable_array` elements, and custom fields — so a small frame cannot smuggle an oversized one (parallels `BER#children`). Nested elements are read via explicit `new`/`read` instead of `IO#read_bytes`; behaviourally identical since `BinData#read` ignores `format` by design.
- **Errors**: new `BinData::ContentTooLarge < ParseError` surfaces through the normal read path un-rewrapped. `ASN1::BER` keeps its typed `ASN1::ContentTooLarge` — now **fully qualified**, because the new ancestor constant would otherwise shadow it in the BER lexical scope (Crystal looks up ancestors before enclosing namespaces).

## Notes
- `remaining_bytes` (`getb_to_end`) is intentionally **not** capped: its size is bounded by actual IO content (read-to-EOF), not an attacker-declared length, so it cannot amplify a tiny frame.

## Tests / gates
- New `spec/bindata_dos_spec.cr`: default-0 unchanged, inclusive boundary, oversized `bytes`/`string`/`array`-count rejected before allocation, propagation into nested-field / array / group / variable_array children, bounded non-advancing loop, and a no-cap-never-raises contract test.
- `crystal spec`: **140 examples, 0 failures** (also under `-Dpreview_mt`). `crystal tool format --check` clean. `bin/ameba`: 0 failures.

Closes P-SEC #1 and #5 of #44.
