### PR TITLE
fix: three P0 correctness bugs (value: coercion, null-string, set_hexstring)

### DIFF
--- a/spec/bindata_asn1_accessors_spec.cr
+++ b/spec/bindata_asn1_accessors_spec.cr
@@ -19,16 +19,20 @@ describe "ASN1::BER typed accessors" do
       ber.get_hexstring.should eq("00ff")
     end
 
-    it "strips 0x prefixes and non-hex separators" do
+    it "strips a single leading 0x prefix" do
       ber = ASN1::BER.new
-      ber.set_hexstring("0xAB:CD")
+      ber.set_hexstring("0xABCD")
       ber.get_hexstring.should eq("abcd")
     end
 
-    it "left-pads an odd-length hexstring" do
-      ber = ASN1::BER.new
-      ber.set_hexstring("ABC")
-      ber.get_hexstring.should eq("0abc")
+    it "rejects interior non-hex instead of silently stripping it" do
+      # A separator inside the string (e.g. "AB:CD") used to be stripped, merging
+      # nibbles; it must now be rejected.
+      expect_raises(ArgumentError) { ASN1::BER.new.set_hexstring("AB:CD") }
+    end
+
+    it "rejects an odd-length hexstring instead of nibble-shifting it" do
+      expect_raises(ArgumentError) { ASN1::BER.new.set_hexstring("ABC") }
     end
   end
 

--- a/spec/bindata_p0_correctness_spec.cr
+++ b/spec/bindata_p0_correctness_spec.cr
@@ -1,0 +1,123 @@
+require "./helper"
+
+# Second-pass audit P0 — confirmed correctness bugs (reproduced against master).
+# This file groups the three mechanical fixes shipped together:
+#   P0#2  `value:` integer coercion silently truncated instead of raising
+#   P0#3  null-terminated String read dropped the last byte when unterminated
+#   P0#5  `set_hexstring` silently corrupted its input (odd pad + greedy strip)
+
+# --- P0#2 ----------------------------------------------------------------------
+
+private class CoercedValue < BinData
+  endian big
+  field n : UInt8, value: -> { 300 }
+end
+
+private class FittingValue < BinData
+  endian big
+  field n : UInt8, value: -> { 42 }
+end
+
+private class BoundaryMax < BinData
+  endian big
+  field n : UInt8, value: -> { 255 }
+end
+
+private class BoundaryOver < BinData
+  endian big
+  field n : UInt8, value: -> { 256 }
+end
+
+private class NegativeSigned < BinData
+  endian big
+  field n : Int8, value: -> { -5 }
+end
+
+describe "P0#2 — value: integer coercion" do
+  it "raises instead of silently truncating an out-of-range value" do
+    # 300 & 0xFF used to write byte 44; an overflowing computed value must fail
+    # loudly rather than corrupt the wire.
+    expect_raises(BinData::WriteError) { CoercedValue.new.to_slice }
+  end
+
+  it "still writes an in-range computed value" do
+    FittingValue.new.to_slice.should eq(Bytes[42])
+  end
+
+  it "accepts the exact unsigned maximum (255) but rejects one past it (256)" do
+    BoundaryMax.new.to_slice.should eq(Bytes[255])
+    expect_raises(BinData::WriteError) { BoundaryOver.new.to_slice }
+  end
+
+  it "preserves a negative value into a signed field" do
+    NegativeSigned.new.to_slice.should eq(Bytes[251]) # -5 two's-complement
+  end
+end
+
+# --- P0#3 ----------------------------------------------------------------------
+
+private class NullString < BinData
+  field text : String
+end
+
+describe "P0#3 — null-terminated String read" do
+  it "keeps every byte when the stream has no terminator" do
+    # "ABC" without a trailing NUL used to decode to "AB".
+    NullString.from_slice(Bytes[0x41, 0x42, 0x43]).text.should eq("ABC")
+  end
+
+  it "stops at and strips the NUL terminator" do
+    str = NullString.from_slice(Bytes[0x41, 0x42, 0x43, 0x00, 0x44])
+    str.text.should eq("ABC")
+  end
+
+  it "round-trips through write (re-appends the terminator)" do
+    str = NullString.new
+    str.text = "ABC"
+    NullString.from_slice(str.to_slice).text.should eq("ABC")
+  end
+
+  it "reads an empty string from an empty stream" do
+    NullString.from_slice(Bytes.new(0)).text.should eq("")
+  end
+end
+
+# --- P0#5 ----------------------------------------------------------------------
+
+describe "P0#5 — set_hexstring" do
+  it "decodes a clean even-length hexstring" do
+    ber = ASN1::BER.new
+    ber.set_hexstring("ABCD")
+    ber.get_hexstring.should eq("abcd")
+  end
+
+  it "accepts a single leading 0x prefix" do
+    ber = ASN1::BER.new
+    ber.set_hexstring("0xABCD")
+    ber.get_hexstring.should eq("abcd")
+  end
+
+  it "accepts an uppercase 0X prefix but rejects a doubled prefix" do
+    ber = ASN1::BER.new
+    ber.set_hexstring("0XABCD")
+    ber.get_hexstring.should eq("abcd")
+    # only one prefix is stripped, so the leftover "0x" is invalid hex.
+    expect_raises(ArgumentError) { ASN1::BER.new.set_hexstring("0x0xABCD") }
+  end
+
+  it "rejects an odd-length hexstring instead of nibble-shifting it" do
+    # "ABC" used to become 0x0A 0xBC (every nibble shifted).
+    expect_raises(ArgumentError) { ASN1::BER.new.set_hexstring("ABC") }
+  end
+
+  it "rejects embedded non-hex instead of silently merging nibbles" do
+    # "AB0xCD" used to be stripped to "ABCD"; an interior 0x must not be removed.
+    expect_raises(ArgumentError) { ASN1::BER.new.set_hexstring("AB0xCD") }
+  end
+
+  it "round-trips raw bytes through get_hexstring" do
+    ber = ASN1::BER.new
+    ber.set_hexstring("00ff10")
+    ber.get_bytes.should eq(Bytes[0x00, 0xFF, 0x10])
+  end
+end

--- a/src/bindata.cr
+++ b/src/bindata.cr
@@ -223,8 +223,10 @@ abstract class BinData
                 @{{part[:name]}} = String.new(%buf)
               {% end %}
             {% else %}
-              # Assume the string is 0 terminated
-              @{{part[:name]}} = (io.gets('\0') || "")[0..-2]
+              # Assume the string is 0 terminated. `chomp: true` drops the
+              # terminator without trimming a real byte when the stream ends
+              # without one (a bare `[0..-2]` corrupted unterminated input).
+              @{{part[:name]}} = io.gets('\0', chomp: true) || ""
             {% end %}
 
           {% elsif part[:type] == "bitfield" %}
@@ -327,16 +329,18 @@ abstract class BinData
           {% if part[:value] %}
             # check if we need to configure the value
             %value = ({{part[:value]}}).call
-            # This coerces the proc's result to the field's type. Integers use
-            # `| value` to coerce width; floats can't (no bitwise `|`), so they
-            # are built directly; any other basic type is assigned as-is.
+            # This coerces the proc's result to the field's type with a checked
+            # conversion: `Type.new(value)` raises `OverflowError` if the computed
+            # value doesn't fit, rather than the old `Type.new(0) | value` which
+            # silently truncated (e.g. a UInt8 field with `value: -> { 300 }` wrote
+            # byte 44). Floats and any other basic type are built/assigned directly.
             # NOTE:: `if %value.is_a?(Number)` had issues with `String` due to `.new(0)`
             {% if part[:type] == "basic" %}
               {% basic_type = part[:cls].resolve %}
               {% if basic_type == Float32 || basic_type == Float64 %}
                 @{{part[:name]}} = {{part[:cls]}}.new(%value)
               {% elsif {Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128}.includes?(basic_type) %}
-                @{{part[:name]}} = {{part[:cls]}}.new(0) | %value
+                @{{part[:name]}} = {{part[:cls]}}.new(%value)
               {% else %}
                 @{{part[:name]}} = %value
               {% end %}

--- a/src/bindata/asn1/data_types.cr
+++ b/src/bindata/asn1/data_types.cr
@@ -138,9 +138,12 @@ class ASN1::BER < BinData
     self.tag_class = tag_class
     self.tag_number = tag
 
-    string = string.gsub(/(0x|[^0-9A-Fa-f])*/, "")
-    string = "0#{string}" if string.size % 2 > 0
-    @payload = string.hexbytes
+    # Only a single leading `0x`/`0X` is stripped; everything else must already
+    # be clean even-length hex. The old code stripped non-hex *anywhere* (merging
+    # nibbles) and left-padded an odd length (shifting every nibble) — both
+    # silent corruption. `hexbytes?` rejects odd length and stray characters.
+    hex = string.lchop("0x").lchop("0X")
+    @payload = hex.hexbytes? || raise ArgumentError.new("invalid hexstring: #{string.inspect}")
     self
   end
 


### PR DESCRIPTION
First grouped **P0** PR from the second-pass audit (#44) — three confirmed correctness bugs, each reproduced against `master` and each turning *silent corruption* into a loud, typed failure. One commit, TDD (new `spec/bindata_p0_correctness_spec.cr`).

Scope note: the two indefinite-length P0 items (nested `00 00` truncation, indefinite round-trip) are **not** here — they share their root with the indefinite-length TLV rewrite (item 3a you greenlit), so I'll fix them together there. `get_integer_bytes` (P0#8) is a *contract* question I'll raise separately rather than guess at.

## Fixes

### P0#2 — `value:` integer coercion silently truncated
`field n : UInt8, value: -> { 300 }` wrote byte **44** (`300 & 0xFF`). The macro used `Type.new(0) | value` (silent width coercion); switched to the checked `Type.new(value)`, which raises `OverflowError` (wrapped as `BinData::WriteError`).

⚠️ **Consumer-visible behaviour change** (justifies the major already in flight): a computed length/checksum field whose value overflows the field width now **raises** instead of silently wrapping. In-range values, floats, enums, and negative-into-signed (`Int8, value: -> { -5 }` → `0xFB`) are unaffected — verified.

### P0#3 — null-terminated `String` read dropped the last byte
`(io.gets('\0') || "")[0..-2]` blindly trimmed the last char, so an **unterminated** `"ABC"` decoded to `"AB"`. Now `io.gets('\0', chomp: true)` strips the terminator only when present. Terminated strings, empty strings, EOF, and writer round-trip (the writer re-appends the `0` byte) all preserved.

### P0#5 — `set_hexstring` silently corrupted input
`gsub(/(0x|[^0-9A-Fa-f])*/, "")` stripped non-hex **anywhere** (`"AB0xCD"` → `"ABCD"`, merging nibbles) and left-padded an odd length (`"ABC"` → `0x0ABC`, shifting every nibble). Now strips only a single leading `0x`/`0X` and decodes via `hexbytes?`, raising `ArgumentError` on odd-length or non-hex input.

_Error type:_ kept `ArgumentError` (caller-input validation; `String#hexbytes` itself raises it) rather than an `ASN1::Error` subtype. Happy to switch to a typed ASN.1 error if you'd prefer setter-family consistency with `set_object_id`.

Two characterisation specs in `bindata_asn1_accessors_spec.cr` that pinned the old buggy hexstring behaviour are updated to assert the corrected behaviour.

## Tests / gates
- New `spec/bindata_p0_correctness_spec.cr` incl. boundary (255 writes / 256 raises), negative-into-signed, `0x`/`0X`/double-prefix, terminated/unterminated/empty/round-trip.
- `crystal spec`: **143 examples, 0 failures** (also under `-Dpreview_mt`). `crystal tool format --check` clean. `bin/ameba`: 0 failures.

Refs P0#2 / P0#3 / P0#5 of #44.
