### PR TITLE
fix(asn1): reject out-of-range BER tag numbers instead of truncating

### DIFF
--- a/spec/bindata_asn1_tag_number_spec.cr
+++ b/spec/bindata_asn1_tag_number_spec.cr
@@ -1,0 +1,49 @@
+require "./helper"
+
+# Second-pass audit P0#1 — `BER#tag_number=` stored the value straight into the
+# 5-bit identifier field, so a tag of 32..255 was silently truncated to its low
+# 5 bits (50 -> 18 on the wire) and a value >= 256 leaked a raw `OverflowError`.
+# The 5-bit field can only hold 0..30 (31 is the reserved high-tag-number escape;
+# tags >= 31 need the extended continuation-byte form, which this accessor does
+# not emit). Out-of-range values now raise a typed `ASN1::InvalidTag`.
+
+describe "ASN1::BER#tag_number=" do
+  it "accepts the in-range maximum (30) and round-trips on the wire" do
+    ber = ASN1::BER.new
+    ber.tag_class = ASN1::BER::TagClass::Application
+    ber.tag_number = 30
+    ber.tag_number.should eq(30)
+
+    rt = IO::Memory.new(ber.to_slice).read_bytes(ASN1::BER)
+    rt.tag_number.should eq(30)
+  end
+
+  it "accepts the in-range minimum (0)" do
+    ber = ASN1::BER.new
+    ber.tag_number = 0
+    ber.tag_number.should eq(0)
+  end
+
+  it "accepts every universal tag (all <= 30)" do
+    ber = ASN1::BER.new
+    ber.tag_number = ASN1::BER::UniversalTags::BMPString # 30, the largest
+    ber.tag_number.should eq(30)
+  end
+
+  it "rejects a tag that would truncate to 5 bits instead of silently corrupting" do
+    # 50 & 0b11111 == 18 used to be written to the wire.
+    expect_raises(ASN1::InvalidTag) { ASN1::BER.new.tag_number = 50 }
+  end
+
+  it "rejects the reserved high-tag-number escape (31)" do
+    expect_raises(ASN1::InvalidTag) { ASN1::BER.new.tag_number = 31 }
+  end
+
+  it "rejects a value >= 256 with a typed error instead of OverflowError" do
+    expect_raises(ASN1::InvalidTag) { ASN1::BER.new.tag_number = 300 }
+  end
+
+  it "rejects a negative tag number" do
+    expect_raises(ASN1::InvalidTag) { ASN1::BER.new.tag_number = -1 }
+  end
+end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -68,7 +68,17 @@ module ASN1
     end
 
     def tag_number=(tag_type : Int | UniversalTags)
-      @identifier.tag_number = tag_type.to_i.to_u8
+      n = tag_type.to_i
+      # The identifier's tag-number field is 5 bits, so only 0..30 fit directly.
+      # 31 (0b11111) is the reserved high-tag-number escape, and any value >= 31
+      # requires the extended continuation-byte form, which this accessor does
+      # not emit. Reject out-of-range values with a typed error rather than
+      # silently truncating to 5 bits (50 -> 18) or leaking an `OverflowError`
+      # from `to_u8` (>= 256). High-tag-number write support is tracked in #44.
+      unless 0 <= n <= 30
+        raise ASN1::InvalidTag.new("invalid tag number #{n}: must be 0..30 (high-tag-number form is not supported by tag_number=)")
+      end
+      @identifier.tag_number = n.to_u8
     end
 
     # The universal tag as a `UniversalTags` enum. Raises unless this is a


### PR DESCRIPTION
P0#1 from the second-pass audit (#44).

## Problem
`BER#tag_number=` did `@identifier.tag_number = tag_type.to_i.to_u8`, storing straight into the identifier's **5-bit** tag-number field. So:
- a tag of 32..255 was **silently truncated** to its low 5 bits — `tag_number = 50` wrote **18** to the wire;
- a value ≥ 256 leaked a raw **`OverflowError`** from `to_u8`.

## Fix
Only **0..30** fit the 5-bit field. **31** (`0b11111`) is the reserved high-tag-number escape, and any value ≥ 31 requires the extended continuation-byte form, which this accessor does not emit. The setter now validates the range and raises a typed **`ASN1::InvalidTag`** for anything outside 0..30:

```crystal
def tag_number=(tag_type : Int | UniversalTags)
  n = tag_type.to_i
  unless 0 <= n <= 30
    raise ASN1::InvalidTag.new("invalid tag number #{n}: must be 0..30 (high-tag-number form is not supported by tag_number=)")
  end
  @identifier.tag_number = n.to_u8
end
```

## Scope
This stops the silent corruption / untyped leak. Actually **emitting** the high-tag-number (extended) form for tags ≥ 31 is a separate feature (the P2 "high-tag set API" in #44) with an API-shape decision, so it's deliberately not bundled here. The existing high-tag-number **read** path (`Identifier#read`/`#write`) is untouched — it uses the `Identifier` bitfield setter directly, not this facade, and its round-trip specs still pass.

## Non-breaking
Every `UniversalTags` member is ≤ 30 (`BMPString` = 30), so no `set_*` accessor or existing spec is affected. Only callers that were *already being silently corrupted* (a custom tag > 30) now get a clear error.

## Tests / gates
- New `spec/bindata_asn1_tag_number_spec.cr`: accepts 0 / 30 / `BMPString`, wire round-trip at 30, rejects 31 / 50 / 300 / -1 with `ASN1::InvalidTag`.
- `crystal spec`: **134 examples, 0 failures**. `crystal tool format --check` clean. `bin/ameba`: 0 failures.

Refs P0#1 of #44.
