### PR TITLE
feat(asn1): add propagated max_depth to bound nested children parsing

### DIFF
--- a/spec/bindata_asn1_max_depth_spec.cr
+++ b/spec/bindata_asn1_max_depth_spec.cr
@@ -1,0 +1,72 @@
+require "./helper"
+
+# Second-pass audit P-SEC (medium) — `max_content_length` caps bytes, not
+# nesting depth. A few KB of `30 80 30 80 …` encodes thousands of levels, and a
+# consumer that walks `children` recursively blows its stack (unrescuable in
+# Crystal). A propagated `max_depth` (default 100) makes `children` raise a typed
+# `ASN1::MaxDepthExceeded` once the nesting limit is reached.
+
+# Builds `levels` nested definite-length SEQUENCEs wrapping an INTEGER 0.
+# Kept shallow so every length stays in short form (< 128).
+private def nested_seq(levels : Int32) : Bytes
+  data = Bytes[0x02, 0x01, 0x00] # INTEGER 0
+  levels.times do
+    inner = data
+    data = Bytes.new(inner.size + 2)
+    data[0] = 0x30_u8 # constructed SEQUENCE
+    data[1] = inner.size.to_u8
+    inner.each_with_index { |b, i| data[i + 2] = b }
+  end
+  data
+end
+
+# Fully descends the constructed tree, forcing a `children` call at every level.
+private def walk(ber : ASN1::BER) : Nil
+  return unless ber.constructed
+  ber.children.each { |child| walk(child) }
+end
+
+describe "ASN1::BER max_depth" do
+  it "defaults to 100" do
+    ASN1::BER.new.max_depth.should eq(100)
+  end
+
+  it "walks a tree within the depth limit" do
+    ber = IO::Memory.new(nested_seq(4)).read_bytes(ASN1::BER)
+    ber.max_depth = 4
+    walk(ber) # 4 SEQUENCE levels -> deepest children() is on depth 3, allowed
+  end
+
+  it "raises once the nesting exceeds the limit" do
+    ber = IO::Memory.new(nested_seq(4)).read_bytes(ASN1::BER)
+    ber.max_depth = 3
+    expect_raises(ASN1::MaxDepthExceeded) { walk(ber) }
+  end
+
+  it "treats 0 as unlimited" do
+    ber = IO::Memory.new(nested_seq(6)).read_bytes(ASN1::BER)
+    ber.max_depth = 0
+    walk(ber) # no limit -> no raise
+  end
+
+  it "pins the exact boundary (N descents allowed)" do
+    # SEQUENCE { SEQUENCE { INTEGER } }: walking calls children() at depth 0 then 1.
+    two = nested_seq(2)
+
+    # max_depth = 1 allows the descent at depth 0 but raises at depth 1.
+    one = IO::Memory.new(two).read_bytes(ASN1::BER)
+    one.max_depth = 1
+    expect_raises(ASN1::MaxDepthExceeded) { walk(one) }
+
+    # max_depth = 2 allows both descents (the leaf INTEGER is primitive).
+    ok = IO::Memory.new(two).read_bytes(ASN1::BER)
+    ok.max_depth = 2
+    walk(ok)
+  end
+
+  it "propagates the limit onto each child" do
+    ber = IO::Memory.new(nested_seq(2)).read_bytes(ASN1::BER)
+    ber.max_depth = 7
+    ber.children.first.max_depth.should eq(7)
+  end
+end

--- a/src/bindata/asn1.cr
+++ b/src/bindata/asn1.cr
@@ -47,6 +47,17 @@ module ASN1
     #     ber.read(io)
     property max_content_length : Int32 = 0
 
+    # Maximum nesting depth that `#children` will descend before raising
+    # `MaxDepthExceeded`. The default (100) guards a recursive consumer walk
+    # against stack overflow on a deeply nested message (a few KB of `30 80 …`
+    # encodes thousands of levels); `0` disables the limit. Propagated to each
+    # child alongside `max_content_length`.
+    property max_depth : Int32 = 100
+
+    # This element's depth in the parse tree (root = 0). Set by the parent's
+    # `#children` so the limit is enforced relative to where parsing started.
+    protected property depth : Int32 = 0
+
     def tag_class
       @identifier.tag_class
     end
@@ -154,14 +165,23 @@ module ASN1
     end
 
     # Parses the payload as a sequence of nested BER elements. The
-    # `max_content_length` cap propagates to each child.
+    # `max_content_length` and `max_depth` caps propagate to each child.
     def children
+      # Refuse to descend past the limit, so a recursive consumer walk gets a
+      # typed error instead of a stack overflow on a deeply nested message.
+      if @max_depth > 0 && @depth >= @max_depth
+        raise MaxDepthExceeded.new("ASN.1 nesting depth exceeds max_depth #{@max_depth}")
+      end
+
       parts = [] of BER
       io = IO::Memory.new(@payload)
       while io.pos < io.size
-        # Propagate the cap so a small frame can't smuggle an oversized child.
+        # Propagate the caps so a small frame can't smuggle an oversized or
+        # over-deep child.
         child = BER.new
         child.max_content_length = @max_content_length
+        child.max_depth = @max_depth
+        child.depth = @depth + 1
         child.read(io)
         parts << child
       end

--- a/src/bindata/asn1/exceptions.cr
+++ b/src/bindata/asn1/exceptions.cr
@@ -16,6 +16,9 @@ module ASN1
   # Raised when a declared content length exceeds `ASN1::BER#max_content_length`.
   class ContentTooLarge < Error; end
 
+  # Raised when nested `ASN1::BER#children` parsing exceeds `max_depth`.
+  class MaxDepthExceeded < Error; end
+
   # Raised when a BER length is malformed or exceeds the representable range.
   class InvalidLength < Error; end
 end


### PR DESCRIPTION
Item 4 (`max_depth`) from the security pass in #44 — the one you greenlit with *"yes, a configurable depth with reasonable default"*.

## Problem
`max_content_length` caps payload **bytes**, not nesting **depth**. A few KB of `30 80 30 80 …` (or `30 02 30 02 …`) encodes thousands of nested levels. The library itself doesn't recurse, but a consumer that walks `children` recursively — the normal way to traverse a SEQUENCE/SET tree — blows its stack, and a stack overflow is **unrescuable** in Crystal.

## Fix
Add `ASN1::BER#max_depth` (**default 100**, `0` = unlimited), propagated to each child alongside `max_content_length`. Each element tracks its `depth` (root = 0, set by the parent's `children`), and `children` raises a typed **`ASN1::MaxDepthExceeded`** once the limit is reached — turning the stack overflow into a catchable error.

```crystal
def children
  if @max_depth > 0 && @depth >= @max_depth
    raise MaxDepthExceeded.new("ASN.1 nesting depth exceeds max_depth #{@max_depth}")
  end
  # ... each child inherits max_content_length, max_depth, and depth + 1
end
```

`max_depth = N` permits **N levels of `children` descent** from the element it's set on. `depth` is a `protected property`, so a consumer can't reset it to defeat the guard.

## Scope / notes
- Enforced in `children` — the only place a child BER is built from a parent's payload (verified: no typed accessor bypasses it). `inspect`/`read`/`children=` don't recurse, so they need no guard.
- Default **100** is far beyond any realistic ASN.1 nesting (X.509/LDAP/SNMP are single/low-double-digit deep), so legitimate consumers are unaffected; only pathological (attack) depths raise.
- Generic-DSL nesting is statically bounded by the type declarations, so this is ASN.1-only (a self-referential recursive DSL type would be a separate concern, not in the audit).

## Tests / gates
- New `spec/bindata_asn1_max_depth_spec.cr`: default = 100, walk within limit, raise past limit, `0` = unlimited, **exact boundary** (N descents), and direct child propagation (`children.first.max_depth`).
- `crystal spec`: **133 examples, 0 failures**. `crystal tool format --check` clean. `bin/ameba`: 0 failures.

Refs the P-SEC depth item of #44.
